### PR TITLE
 Resize mobile sheets to the visible viewport when the keyboard opens…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -137,22 +137,23 @@ input[type="radio"] {
 
 @media (max-width: 767px) {
   html[data-wherekeep-keyboard="open"] .wherekeep-modal-content {
+    max-height: var(--wherekeep-mobile-sheet-height, 100svh) !important;
     overflow-y: auto !important;
     overscroll-behavior: contain;
-    scroll-padding-bottom: calc(var(--wherekeep-keyboard-inset, 0px) + 8rem);
+    scroll-padding-bottom: 6rem;
   }
 
   html[data-wherekeep-keyboard="open"] .wherekeep-modal-body {
     flex: 0 0 auto !important;
     overflow: visible !important;
-    padding-bottom: 1rem !important;
+    padding-bottom: max(1rem, env(safe-area-inset-bottom)) !important;
   }
 
   html[data-wherekeep-keyboard="open"] .wherekeep-modal-footer {
     position: static !important;
     bottom: auto !important;
     box-shadow: none !important;
-    margin-bottom: var(--wherekeep-keyboard-inset, 0px);
+    margin-bottom: 0 !important;
     padding-bottom: max(1rem, env(safe-area-inset-bottom)) !important;
   }
 }

--- a/components/app-shell/MobileViewportInsets.jsx
+++ b/components/app-shell/MobileViewportInsets.jsx
@@ -8,6 +8,8 @@ export default function MobileViewportInsets() {
     const visualViewport = window.visualViewport;
     let stableHeight = Math.max(window.innerHeight, visualViewport?.height ?? 0);
     let lastWidth = window.innerWidth;
+    let frameId = 0;
+    const pendingTimeouts = new Set();
 
     const setInsets = () => {
       const currentWidth = window.innerWidth;
@@ -26,36 +28,70 @@ export default function MobileViewportInsets() {
         stableHeight - viewportHeight - viewportOffsetTop
       );
       const usableKeyboardInset = keyboardInset > 80 ? keyboardInset : 0;
+      const sheetHeight =
+        usableKeyboardInset > 0
+          ? Math.max(320, stableHeight - usableKeyboardInset)
+          : stableHeight;
 
       root.style.setProperty(
         "--wherekeep-mobile-sheet-height",
-        `${stableHeight}px`
+        `${Math.round(sheetHeight)}px`
+      );
+      root.style.setProperty(
+        "--wherekeep-mobile-layout-height",
+        `${Math.round(stableHeight)}px`
       );
       root.style.setProperty(
         "--wherekeep-keyboard-inset",
-        `${usableKeyboardInset}px`
+        `${Math.round(usableKeyboardInset)}px`
       );
       root.dataset.wherekeepKeyboard =
         usableKeyboardInset > 0 ? "open" : "closed";
     };
 
+    const scheduleSetInsets = () => {
+      if (frameId) window.cancelAnimationFrame(frameId);
+
+      frameId = window.requestAnimationFrame(() => {
+        frameId = 0;
+        setInsets();
+
+        for (const delay of [90, 240]) {
+          const timeoutId = window.setTimeout(() => {
+            pendingTimeouts.delete(timeoutId);
+            setInsets();
+          }, delay);
+          pendingTimeouts.add(timeoutId);
+        }
+      });
+    };
+
     const resetStableHeight = () => {
       stableHeight = 0;
-      window.requestAnimationFrame(setInsets);
+      scheduleSetInsets();
     };
 
     setInsets();
     window.addEventListener("resize", setInsets);
     window.addEventListener("orientationchange", resetStableHeight);
+    window.addEventListener("focusin", scheduleSetInsets);
+    window.addEventListener("focusout", scheduleSetInsets);
     visualViewport?.addEventListener("resize", setInsets);
     visualViewport?.addEventListener("scroll", setInsets);
 
     return () => {
+      if (frameId) window.cancelAnimationFrame(frameId);
+      for (const timeoutId of pendingTimeouts) {
+        window.clearTimeout(timeoutId);
+      }
       window.removeEventListener("resize", setInsets);
       window.removeEventListener("orientationchange", resetStableHeight);
+      window.removeEventListener("focusin", scheduleSetInsets);
+      window.removeEventListener("focusout", scheduleSetInsets);
       visualViewport?.removeEventListener("resize", setInsets);
       visualViewport?.removeEventListener("scroll", setInsets);
       root.style.removeProperty("--wherekeep-mobile-sheet-height");
+      root.style.removeProperty("--wherekeep-mobile-layout-height");
       root.style.removeProperty("--wherekeep-keyboard-inset");
       delete root.dataset.wherekeepKeyboard;
     };

--- a/components/items/GlobalItemSearchModal.jsx
+++ b/components/items/GlobalItemSearchModal.jsx
@@ -234,6 +234,33 @@ export default function GlobalItemSearchModal({ isOpen, onClose }) {
     router.push("/items");
   };
 
+  const renderSearchInput = ({ autoFocus = false, className = "" } = {}) => (
+    <Input
+      autoFocus={autoFocus}
+      value={query}
+      onValueChange={setQuery}
+      placeholder="Search your home..."
+      startContent={<FaSearch className="text-gray-400" />}
+      endContent={
+        <div className="flex items-center gap-2">
+          {isSearching && <FaSpinner className="animate-spin text-gray-400" />}
+          <button
+            type="button"
+            aria-label="Voice search"
+            onClick={showVoiceSearchToast}
+            className="grid h-8 w-8 place-items-center rounded-full text-[var(--stocksense-brand)] transition hover:bg-[var(--stocksense-brand-soft)]"
+          >
+            <FaMicrophone className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      }
+      variant="bordered"
+      radius="lg"
+      className={className}
+      classNames={modalInputClassNames}
+    />
+  );
+
   return (
     <Modal
       isOpen={isOpen}
@@ -254,11 +281,14 @@ export default function GlobalItemSearchModal({ isOpen, onClose }) {
       >
         {() => (
           <>
-            <ModalHeader className={`flex flex-col gap-1 max-md:sticky max-md:top-0 max-md:z-20 max-md:border-b max-md:border-[var(--stocksense-brand-border)] max-md:bg-[var(--stocksense-brand-soft)] max-md:px-4 max-md:py-3 ${modalHeaderClass}`}>
+            <ModalHeader className={`flex flex-col gap-2 max-md:sticky max-md:top-0 max-md:z-20 max-md:border-b max-md:border-[var(--stocksense-brand-border)] max-md:bg-[var(--stocksense-brand-soft)] max-md:px-4 max-md:py-3 ${modalHeaderClass}`}>
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[var(--stocksense-brand)]">
+                <span className="hidden text-[var(--stocksense-brand)] md:inline">
                   Search
                 </span>
+                <div className="min-w-0 flex-1 md:hidden">
+                  {renderSearchInput()}
+                </div>
                 <button
                   type="button"
                   aria-label="Close search"
@@ -274,31 +304,10 @@ export default function GlobalItemSearchModal({ isOpen, onClose }) {
             </ModalHeader>
 
             <ModalBody className={`${modalBodyClass} flex flex-col space-y-4 max-md:bg-gray-50 max-md:px-4 max-md:!pb-4 max-md:pt-3`}>
-              <Input
-                autoFocus={shouldAutoFocusSearch}
-                value={query}
-                onValueChange={setQuery}
-                placeholder="Search your home..."
-                startContent={<FaSearch className="text-gray-400" />}
-                endContent={
-                  <div className="flex items-center gap-2">
-                    {isSearching && (
-                      <FaSpinner className="animate-spin text-gray-400" />
-                    )}
-                    <button
-                      type="button"
-                      aria-label="Voice search"
-                      onClick={showVoiceSearchToast}
-                      className="grid h-8 w-8 place-items-center rounded-full text-[var(--stocksense-brand)] transition hover:bg-[var(--stocksense-brand-soft)]"
-                    >
-                      <FaMicrophone className="h-3.5 w-3.5" />
-                    </button>
-                  </div>
-                }
-                variant="bordered"
-                radius="lg"
-                classNames={modalInputClassNames}
-              />
+              {renderSearchInput({
+                autoFocus: shouldAutoFocusSearch,
+                className: "max-md:hidden",
+              })}
 
               {toastMessage && (
                 <div className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm">


### PR DESCRIPTION
… so lower form content remains scrollable,

  including shopping list photo controls. Move the global mobile search input into the header beside the close button.