### PR TITLE
feat: add household tasks with activity-aware navigation

### DIFF
--- a/.tmp-landing-preview.log
+++ b/.tmp-landing-preview.log
@@ -1,0 +1,21 @@
+   ▲ Next.js 15.5.7 (Turbopack)
+   - Local:        http://localhost:3101
+   - Network:      http://192.168.1.7:3101
+   - Environments: .env.local
+   - Experiments (use with caution):
+     · serverActions
+     · optimizePackageImports
+
+ ✓ Starting...
+ ✓ Compiled middleware in 109ms
+ ✓ Ready in 1033ms
+ ○ Compiling / ...
+ ✓ Compiled / in 2.2s
+ GET / 200 in 661ms
+ GET / 200 in 490ms
+ GET / 200 in 410ms
+ GET / 200 in 425ms
+ GET / 200 in 418ms
+ GET / 200 in 398ms
+ GET / 200 in 440ms
+ GET / 200 in 457ms

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WhereKeep
 
-WhereKeep is a household inventory app for tracking what you have, where it is stored, what needs attention, and what needs to be bought again. It supports shared households, role-based editing, locations, storage areas, categories, item search, shopping lists, expiration tracking, images, barcode-assisted item entry, voice-assisted quick add, billing plans, mobile-first workflows, and session management.
+WhereKeep is a household inventory app for tracking what you have, where it is stored, what needs attention, what needs to be bought again, and which household tasks need to be done. It supports shared households, role-based editing, locations, storage areas, categories, item search, shopping lists, household tasks and chores, expiration tracking, images, barcode-assisted item entry, voice-assisted quick add, billing plans, mobile-first workflows, activity tracking, and session management.
 
 ## Tech Stack
 
@@ -83,6 +83,8 @@ Protected routes include:
 - `/categories`
 - `/items`
 - `/shopping-list`
+- `/tasks`
+- `/activity`
 - `/profile`
 
 ## Performance Notes
@@ -93,16 +95,28 @@ Protected routes include:
 - Public image assets get long-lived immutable cache headers from `next.config.mjs`.
 - Next Image is configured to emit AVIF/WebP variants and cache optimized images.
 - Package import optimization is enabled for the icon packages used by the app.
-- The support chatbot, bulk move modal, and barcode scanner are lazy-loaded so they do not ship in initial route bundles until needed.
+- The support chatbot, tasks client, bulk move modal, and barcode scanner are lazy-loaded so they do not ship in initial route bundles until needed.
 - App image helpers default to lazy loading and async decoding.
+- Activity loading skips redundant task queries when filters cannot match task activity and skips image URL enrichment when no image paths are present.
+- Navigation attention counts load inventory and task counts in parallel where possible.
 
-Current verification command:
+Current verification commands:
 
 ```bash
+npm run test:unit
+npm run test:e2e
 npm run build
 ```
 
-This repo does not currently include an ESLint config. Add one before reintroducing a lint script.
+This repo does not currently include an ESLint config or `lint` script. `next build` still runs Next's build-time validation.
+
+Latest production build snapshot:
+
+- Shared first-load JS: 103 kB
+- Middleware: 74.9 kB
+- `/tasks`: 1.3 kB route size, 104 kB first-load JS
+- `/dashboard`: 4.69 kB route size, 137 kB first-load JS
+- `/activity`: 173 B route size, 131 kB first-load JS
 
 ## Project Structure
 
@@ -117,7 +131,8 @@ app/
     locations/
     profile/
     shopping-list/
-  actions/              Server actions for auth, billing, inventory, households, preferences, and activity
+    tasks/
+  actions/              Server actions for auth, billing, inventory, households, preferences, activity, and tasks
   api/                  API routes for session sync and Stripe webhooks
   auth/                 Supabase auth confirmation route
   contact/              Public contact page
@@ -138,6 +153,7 @@ components/
   modals/               Shared modal theme and controls
   profile/              Profile client UI
   shopping-list/        Shopping list page and modals
+  tasks/                Tasks page client, cards, filters, editor, and completion UI
   ui/                   Shared UI components
 
 lib/
@@ -153,6 +169,7 @@ utils/
   households.js         Household roles, limits, and membership helpers
   inventoryImages.js    Image storage entity metadata and signed URL helpers
   metadata.js           App metadata helpers
+  tasks.js              Task validation, permissions, grouping, sorting, and recurrence helpers
   stripe.js             Stripe client helper
 ```
 
@@ -186,6 +203,23 @@ Supported image entity types:
 
 Images are limited to JPG, PNG, WebP, or GIF files up to 5 MB. The app stores image paths in the database and serves signed URLs from the shared `inventory-images` Supabase Storage bucket.
 
+## Tasks And Activity
+
+Household tasks live under `/tasks` and are backed by the Supabase `tasks` table. Tasks support assignment, optional locations, due dates, priority, recurrence, completion, reopening, deletion, filtering, sorting, and mobile-friendly task cards.
+
+Task permissions follow household roles:
+
+- Owners and editors can create, edit, assign, delete, complete, and reopen household tasks.
+- Owners and editors can create, edit, assign, and delete household tasks.
+- Viewers can view household tasks but cannot create, edit, assign, or delete them.
+- Any household member can complete or reopen a task only when it is assigned to them or unassigned.
+
+Recurring chores use an occurrence-generation model: completing a recurring task keeps the completed record for history and creates the next task occurrence from the recurrence settings when needed.
+
+Task create, update, completion, reopen, and delete actions write to `activity_events` and appear in Recent Activity. The activity page supports filtering by activity type, including locations, storage areas, categories, items, shopping list, and tasks. Navigation and notifications show open tasks due today or overdue.
+
+Database migrations for tasks and task activity live under `supabase/migrations/`.
+
 ## Billing
 
 Billing plan definitions live in `utils/billingPlans.js`.
@@ -206,6 +240,7 @@ Stripe checkout and webhook code reads price IDs from environment variables. Kee
 - Use `modalTheme.js` for shared modal and sheet styling.
 - Apply the user's selected color as an accent for controls, active states, icons, and modal headers.
 - When adding image support for a new entity, update the Supabase schema, `INVENTORY_IMAGE_ENTITY`, `getImageEntityRecord`, and the relevant serializer.
+- When adding task behavior, keep authorization in `app/actions/tasks.js` and pure rules in `utils/tasks.js`.
 - If auth behavior looks stale during development, restart the dev server and clear browser cookies for `localhost`.
 
 ## License

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,6 +25,7 @@ npm run test:e2e
 npm run test:e2e:headed
 npm run test:e2e:ui
 npm run test:all
+npm run build
 ```
 
 This repo currently has no ESLint config or type-check script, so lint/type-check commands are not part of the test workflow yet. `next build` still runs Next's build-time checks.
@@ -43,7 +44,7 @@ tests/
 
 ## Fixtures and mocks
 
-- `tests/helpers/factories.js` creates deterministic users, households, locations, storage areas, categories, items, shopping-list entries, and role fixtures.
+- `tests/helpers/factories.js` creates deterministic users, households, locations, storage areas, categories, items, shopping-list entries, tasks, and role fixtures.
 - `tests/mocks/supabase.js` provides chainable Supabase query mocks with sequential table responses.
 - `tests/mocks/stripe.js` provides checkout, billing portal, and webhook mocks.
 - `tests/mocks/session.js` provides Iron Session and verified-session shapes.
@@ -69,6 +70,16 @@ Playwright fails immediately if pointed at `wherekeep.com`, a live Stripe key, o
 
 The current E2E suite covers public pages, login form accessibility, invalid sign-in behavior, and unauthenticated protected-route redirects. Full authenticated inventory, permission, and subscription E2E flows still require an isolated test Supabase project or equivalent local test backend.
 
+## Current task coverage
+
+Task coverage includes:
+
+- Unit tests for task grouping, overdue/due-today/upcoming detection, summary counts, priority sorting, recurrence calculations, payload validation, and permission checks.
+- Integration tests for creating, loading, editing, assigning, completing, reopening, deleting, recurring next-occurrence generation, viewer/editor restrictions, and cross-household rejection.
+- Component tests for task filters, mobile tab behavior, task cards, completion controls, action visibility, completed task edit restrictions, toasts, and error display.
+- Activity integration tests for task activity fallback loading, task-only filtering, non-task filtering, actor fallback, and merged ordering.
+- Dropdown component tests for viewport-aware menu placement near the bottom of the screen.
+
 ## CI
 
 GitHub Actions runs dependency install, unit/integration/component tests, coverage, production build, Playwright browser install, and focused Playwright tests. Playwright reports are uploaded on failure.
@@ -92,6 +103,7 @@ Open the HTML coverage report from `coverage/index.html` after running coverage.
 ## Known gaps
 
 - Full authenticated E2E CRUD flows are not enabled until a safe isolated test backend exists.
+- The authenticated Tasks Playwright flow is not enabled until a safe isolated test backend exists.
 - Supabase Row Level Security is not verified by application mocks.
 - Large inventory page clients still need targeted component or extracted-logic tests.
 
@@ -107,3 +119,8 @@ When a safe test Supabase project or local Supabase stack exists, add SQL/RLS te
 - Invite tokens cannot be reused after revocation, expiration, or acceptance.
 - Owner role cannot be self-elevated or reassigned through direct database writes.
 - Billing and subscription rows cannot be read or modified by unrelated users.
+- Tasks can only be read by household members.
+- Owners and editors can create, edit, assign, and delete household tasks according to the server policy.
+- Viewers cannot create, edit, assign, delete, or modify another member's task.
+- Household members can complete or reopen only tasks assigned to themselves or unassigned.
+- Recurring task completion cannot create duplicate future occurrences after repeated completion requests.

--- a/TESTING_PLAN.md
+++ b/TESTING_PLAN.md
@@ -12,14 +12,35 @@ Major server boundaries:
 - Inventory: `app/actions/server.js`, `app/actions/quickAdd.js`, `utils/pantry/*`, `utils/inventoryImages.js`.
 - Household permissions: `app/actions/household.js`, `utils/households.js`.
 - Billing/subscriptions: `app/actions/billing.js`, `utils/billingPlans.js`, `utils/stripe.js`, `app/api/stripe/webhook/route.js`.
-- Shopping list/activity: `app/actions/shoppingList.js`, `app/actions/activity.js`.
+- Shopping list/activity/tasks: `app/actions/shoppingList.js`, `app/actions/activity.js`, `app/actions/tasks.js`, `utils/tasks.js`.
 - Preferences/UI helpers: `utils/appPreferences.js`, `components/ui/*`, app-shell components.
 
 ## Existing test coverage
 
-There are currently no test files, no Vitest/Jest/Playwright config, no CI workflow, and no package scripts for tests. The only verification script currently present is `npm run build`. The repo also does not currently include an ESLint config or type-check script.
+The repo now has Vitest, React Testing Library, Playwright, V8 coverage, shared mocks, fixtures, and npm test scripts. Current scripts include:
+
+- `npm run test`
+- `npm run test:watch`
+- `npm run test:unit`
+- `npm run test:coverage`
+- `npm run test:e2e`
+- `npm run test:e2e:headed`
+- `npm run test:e2e:ui`
+- `npm run test:all`
+- `npm run build`
+
+The repo still does not include an ESLint config or standalone type-check script. `next build` remains the build-time validation command.
+
+Current coverage areas include:
+
+- Pure utility tests for URL safety, household roles, billing plans, preferences, pantry validation/search/date helpers, shopping-list movement helpers, and task rules.
+- Integration tests for auth/session behavior, verified sessions, billing actions, Stripe webhook handling, household invites, shopping-list actions, activity actions, authenticated shell state, and task server actions.
+- Component tests for dashboard stats, recent activity, task page interactions, and shared dropdown behavior.
+- Playwright tests for public pages, login accessibility, invalid sign-in handling, and unauthenticated protected-route redirects on desktop and mobile.
 
 ## Proposed testing stack
+
+The selected testing stack is:
 
 - Unit and integration tests: Vitest.
 - Component tests: React Testing Library, `@testing-library/user-event`, `@testing-library/jest-dom`, jsdom.
@@ -34,6 +55,7 @@ There are currently no test files, no Vitest/Jest/Playwright config, no CI workf
 - Inventory data integrity: locations, storage areas, categories, items, item moves, item deletion, household scoping, parent-child relationship validation.
 - Search/filter/sort: query normalization, empty and error states, household isolation, mobile and desktop filter flows.
 - Shopping list: create/update/delete/complete/restore flows, low-stock handoff, permissions, household isolation.
+- Tasks: create/update/delete, assign/unassign, due date grouping, priority sorting, completion, reopen, recurrence, dashboard widget, activity logging, household isolation, and viewer/editor/owner behavior.
 - Dashboard/activity: calculations, previews, ordering, pagination, deleted-entity behavior, partial failures.
 - Billing/subscriptions: effective plan detection, status handling, limits, feature gates, Stripe checkout/portal/webhook behavior.
 - Responsive/accessibility: mobile navigation, global add/search, dialogs/drawers, keyboard dismissal, accessible labels and dialog names.
@@ -52,20 +74,31 @@ Phase 1 will not connect to Supabase. Unit and integration tests will use reposi
 
 End-to-end tests must never target production Supabase or live Stripe. E2E configuration will fail fast if pointed at a production URL or production-looking credentials. If a local Supabase setup is added later, tests can opt into it through explicit test-only environment variables. Otherwise, Playwright will use mocked or seeded test flows and Stripe test-mode/mocked endpoints.
 
-## Implementation phases
+## Implementation status
 
-1. Add the test foundation: dependencies, scripts, Vitest config, shared setup, environment example, test folders, helpers/mocks, and initial utility/business-logic tests.
-2. Add auth, session, household role/permission, plan/subscription, and Supabase/session mock tests.
-3. Add inventory, search/filter/sort, shopping list, dashboard, and activity tests.
-4. Add API route, server action, Stripe checkout/portal/webhook, and error-handling tests.
-5. Add Playwright config, core E2E flows, mobile E2E coverage, CI workflow, and testing documentation.
+Completed:
 
-Each phase should run the relevant test command and `npm run build` before continuing. Lint/type-check verification will be added only if the repo gains those scripts/configs.
+- Test foundation: dependencies, scripts, Vitest config, shared setup, environment example, test folders, helpers, and mocks.
+- Auth, session, household role/permission, plan/subscription, and Supabase/session mock tests.
+- Inventory utility, search/filter/sort, shopping list, dashboard, activity, and task business-logic tests.
+- API route and server action tests for critical auth, billing, household, shopping list, activity, and task flows.
+- Playwright config with desktop and mobile public/auth safety coverage.
+- Testing documentation in `README.md`, `TESTING.md`, and this plan.
+
+Still planned:
+
+- Authenticated inventory CRUD Playwright flows against an isolated test backend.
+- Authenticated task CRUD Playwright flow against an isolated test backend.
+- SQL/RLS tests against a safe Supabase project or local Supabase stack.
+- More targeted component coverage for large inventory page clients after behavior-preserving extraction.
+
+Each new phase should run the relevant test command and `npm run build` before continuing. Lint/type-check verification should be added only if the repo gains those scripts/configs.
 
 ## Risks and limitations
 
 - Several important behaviors currently live inside large UI components or large server-action files. Small behavior-preserving extraction may be needed before meaningful tests can target them.
 - The current repo has no lint/type-check setup, so CI cannot honestly run those checks until they are added separately.
 - Full auth, invitation, and billing E2E coverage depends on safe test infrastructure. Until that exists, these paths should be covered through route/action tests and mocked E2E flows.
+- Full authenticated task and inventory E2E coverage depends on safe test infrastructure. Until that exists, these paths should stay covered through utility, component, action, and mocked route tests.
 - Supabase Row Level Security cannot be fully verified from application mocks. Where practical, tests should document expected SQL/RLS checks, but real RLS verification requires a safe test database.
 - Coverage thresholds should start realistic and focus on meaningful business logic instead of forcing low-value UI assertions.

--- a/app/(authenticated)/activity/page.jsx
+++ b/app/(authenticated)/activity/page.jsx
@@ -46,7 +46,7 @@ export default async function ActivityPage() {
           Recent activity
         </h1>
         <p className="mt-1 text-sm text-gray-500">
-          Review additions, updates, moves, removals, and shopping list changes.
+          Review additions, updates, moves, removals, completed tasks, and shopping list changes.
         </p>
       </div>
 

--- a/app/(authenticated)/dashboard/page.jsx
+++ b/app/(authenticated)/dashboard/page.jsx
@@ -4,7 +4,9 @@ import MobileDashboardHome from '@/components/dashboard/MobileDashboardHome';
 import DesktopDashboardToolbar from '@/components/dashboard/DesktopDashboardToolbar';
 import AttentionItemsCard from '@/components/dashboard/AttentionItemsCard';
 import InventoryByLocation from '@/components/dashboard/InventoryByLocation';
+import TasksDueCard from '@/components/dashboard/TasksDueCard';
 import { getAuthenticatedAppShellState } from '@/components/app-shell/authenticatedShellState';
+import { getTasksAction } from '@/app/actions/tasks';
 import { createPageMetadata, NO_INDEX_ROBOTS } from '@/utils/metadata';
 import {
   getHouseholdForUser,
@@ -14,6 +16,11 @@ import {
   getInventoryImageUrls,
 } from '@/utils/inventoryImages';
 import { addDays, toDateString } from '@/utils/pantry/date';
+import {
+  groupTasksByDate,
+  sortTasks,
+  summarizeTasks,
+} from '@/utils/tasks';
 import { LuClock3, LuPackageMinus, LuTriangleAlert } from 'react-icons/lu';
 
 export const metadata = createPageMetadata({
@@ -386,6 +393,35 @@ async function getInventoryByLocation(supabase) {
     );
 }
 
+async function getDashboardTasks(supabase, tasks = []) {
+  const taskSummary = summarizeTasks(tasks);
+  const groupedTasks = groupTasksByDate(sortTasks(tasks));
+  const visibleTasks = [
+    ...groupedTasks.overdue,
+    ...groupedTasks.today,
+    ...groupedTasks.upcoming,
+  ].slice(0, 5);
+  const locationIds = [
+    ...new Set(visibleTasks.map((task) => task.locationId).filter(Boolean)),
+  ];
+  const { data: locationsRaw = [] } = locationIds.length
+    ? await supabase.from('locations').select('id, name').in('id', locationIds)
+    : { data: [] };
+  const locationNameById = new Map(
+    (locationsRaw ?? []).map((location) => [String(location.id), location.name])
+  );
+
+  return {
+    dueTodayCount: taskSummary.dueToday,
+    tasks: visibleTasks.map((task) => ({
+      ...task,
+      locationName: task.locationId
+        ? locationNameById.get(String(task.locationId)) ?? null
+        : null,
+    })),
+  };
+}
+
 export default async function HomePage() {
   const shellState = await getAuthenticatedAppShellState();
   const supabase = await createClient();
@@ -435,11 +471,17 @@ export default async function HomePage() {
     expirationNotifications,
     dashboardAttentionItems,
     inventoryByLocation,
+    tasksResult,
   ] = await Promise.all([
     getExpirationNotifications(supabase, 3, shellState.attentionCounts),
     getDashboardAttentionItems(supabase, 3, shellState.attentionCounts),
     getInventoryByLocation(supabase),
+    getTasksAction(),
   ]);
+  const dashboardTasks = await getDashboardTasks(
+    supabase,
+    tasksResult.data?.items ?? []
+  );
 
   const totals = {
     locations: shellState.attentionCounts.locationsCount,
@@ -513,6 +555,10 @@ export default async function HomePage() {
                 emptyText="No low-stock items."
                 icon={LuPackageMinus}
                 detailType="stock"
+              />
+              <TasksDueCard
+                tasks={dashboardTasks.tasks}
+                dueTodayCount={dashboardTasks.dueTodayCount}
               />
             </div>
           </div>

--- a/app/(authenticated)/tasks/loading.jsx
+++ b/app/(authenticated)/tasks/loading.jsx
@@ -1,0 +1,10 @@
+import PageLoadingState from "@/components/ui/PageLoadingState";
+
+export default function TasksLoading() {
+  return (
+    <PageLoadingState
+      label="Loading tasks..."
+      detail="Checking household chores, assignments, and due dates."
+    />
+  );
+}

--- a/app/(authenticated)/tasks/page.jsx
+++ b/app/(authenticated)/tasks/page.jsx
@@ -1,0 +1,95 @@
+import { LazyTasksPageClient } from "@/components/app-shell/LazyTasksClients";
+import { getTasksAction } from "@/app/actions/tasks";
+import { createAdminClient } from "@/utils/supabase/admin";
+import { createClient } from "@/utils/supabase/server";
+import { getHouseholdForUser, hasHouseholdInviteMetadata } from "@/utils/households";
+import { createPageMetadata, NO_INDEX_ROBOTS } from "@/utils/metadata";
+
+export const metadata = createPageMetadata({
+  title: "Tasks",
+  description: "Assign chores, track household tasks, and keep home routines moving.",
+  path: "/tasks",
+  robots: NO_INDEX_ROBOTS,
+});
+
+function getUserDisplayName(user) {
+  const metadata = user?.user_metadata ?? {};
+  const name =
+    metadata.preferred_name ||
+    metadata.display_name ||
+    metadata.full_name ||
+    metadata.name ||
+    "";
+
+  return name ? String(name).trim() : "";
+}
+
+async function hydrateMemberDisplayNames(admin, members = []) {
+  const uniqueMembers = Array.from(
+    new Map((members ?? []).map((member) => [String(member.user_id), member])).values()
+  ).filter((member) => member?.user_id);
+
+  if (uniqueMembers.length === 0) return members ?? [];
+
+  const displayNameEntries = await Promise.all(
+    uniqueMembers.map(async (member) => {
+      try {
+        const { data, error } = await admin.auth.admin.getUserById(member.user_id);
+        if (error) return [String(member.user_id), ""];
+        return [String(member.user_id), getUserDisplayName(data?.user)];
+      } catch {
+        return [String(member.user_id), ""];
+      }
+    })
+  );
+  const displayNamesByUserId = new Map(displayNameEntries);
+
+  return (members ?? []).map((member) => ({
+    ...member,
+    displayName: displayNamesByUserId.get(String(member.user_id)) || null,
+  }));
+}
+
+export default async function TasksPage() {
+  const supabase = await createClient();
+  const admin = createAdminClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const { household, member } = await getHouseholdForUser({
+    userId: user?.id,
+    email: user?.email,
+    createIfMissing: !hasHouseholdInviteMetadata(user),
+  });
+
+  const [tasksResult, membersResult, locationsResult] = await Promise.all([
+    getTasksAction(),
+    household?.id
+      ? admin
+          .from("household_members")
+          .select("household_id, user_id, email, role")
+          .eq("household_id", household.id)
+          .order("joined_at", { ascending: true })
+      : { data: [] },
+    household?.id
+      ? supabase
+          .from("locations")
+          .select("id, name")
+          .order("name", { ascending: true })
+      : { data: [] },
+  ]);
+  const members = await hydrateMemberDisplayNames(admin, membersResult.data ?? []);
+
+  return (
+    <main className="mx-auto max-w-[1500px] px-5 py-8 md:min-h-[100vh] lg:px-6 xl:px-8 max-md:px-4 max-md:pb-0 max-md:pt-4">
+      <LazyTasksPageClient
+        initialTasks={tasksResult.data?.items ?? []}
+        initialError={tasksResult.error}
+        members={members}
+        locations={locationsResult.data ?? []}
+        currentUserId={user?.id ?? null}
+        currentUserRole={member?.role ?? "viewer"}
+      />
+    </main>
+  );
+}

--- a/app/actions/activity.js
+++ b/app/actions/activity.js
@@ -15,7 +15,16 @@ import {
 
 const DEFAULT_LIMIT = 12;
 const MAX_LIMIT = 50;
-const ACTION_FILTERS = new Set(["added", "updated", "deleted", "moved"]);
+const ACTION_FILTERS = new Set(["added", "updated", "deleted", "moved", "completed"]);
+const TASK_ACTIVITY_ACTIONS = new Set(["added", "updated", "deleted", "completed"]);
+const ENTITY_FILTERS = new Set([
+  "location",
+  "storage_area",
+  "category",
+  "item",
+  "shopping_list_item",
+  "task",
+]);
 
 function normalizeLimit(value) {
   const limit = Number(value);
@@ -26,6 +35,11 @@ function normalizeLimit(value) {
 function normalizeAction(value) {
   const action = typeof value === "string" ? value.toLowerCase() : "";
   return ACTION_FILTERS.has(action) ? action : "all";
+}
+
+function normalizeEntityType(value) {
+  const entityType = typeof value === "string" ? value.toLowerCase() : "";
+  return ENTITY_FILTERS.has(entityType) ? entityType : "all";
 }
 
 function normalizeText(value) {
@@ -157,6 +171,39 @@ function rowTime(value) {
   return Number.isFinite(time) ? time : null;
 }
 
+function activityRowKey(row) {
+  if (row?.id) return `id:${row.id}`;
+  return [
+    row?.entity_type ?? "",
+    row?.entity_id ?? "",
+    row?.action ?? "",
+    row?.created_at ?? "",
+  ].join(":");
+}
+
+function sortActivityRows(rows) {
+  return [...(rows ?? [])].sort((a, b) => {
+    const bTime = rowTime(b?.created_at) ?? 0;
+    const aTime = rowTime(a?.created_at) ?? 0;
+    return bTime - aTime;
+  });
+}
+
+function mergeActivityRows(...rowGroups) {
+  const seen = new Set();
+  const merged = [];
+
+  for (const row of rowGroups.flat()) {
+    if (!row) continue;
+    const key = activityRowKey(row);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(row);
+  }
+
+  return sortActivityRows(merged);
+}
+
 function activityImagePath(row) {
   const changes = row?.changes || {};
   const value = firstValue(
@@ -241,6 +288,9 @@ async function enrichActivityImages(supabase, items) {
       return activityImagePath(row) || imagePathByRowKey.get(`${entityType}:${entityId}`);
     })
     .filter(Boolean);
+
+  if (imagePaths.length === 0) return items;
+
   const urlsByPath = await getInventoryImageUrls(imagePaths, {
     variant: INVENTORY_IMAGE_VARIANT.CARD,
   });
@@ -472,6 +522,49 @@ async function enrichActivityActors(items, householdId) {
   }
 }
 
+async function getTaskActivityRows({
+  householdId,
+  action,
+  actorUserId,
+  entityType,
+  cursor,
+  limit,
+}) {
+  if (!householdId || (entityType !== "all" && entityType !== "task")) return [];
+  if (action !== "all" && !TASK_ACTIVITY_ACTIONS.has(action)) return [];
+
+  try {
+    const admin = createAdminClient();
+    let query = admin
+      .from("activity_events")
+      .select("*")
+      .eq("household_id", householdId)
+      .eq("entity_type", "task")
+      .order("created_at", { ascending: false })
+      .limit(limit + 1);
+
+    if (action !== "all") {
+      query = query.eq("action", action);
+    }
+
+    if (actorUserId) {
+      query = query.eq("actor_user_id", actorUserId);
+    }
+
+    if (cursor) {
+      query = query.lt("created_at", cursor);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return data ?? [];
+  } catch (err) {
+    console.error("getTaskActivityRows error:", err);
+    return [];
+  }
+}
+
 async function getAuthedUser() {
   const { user, error } = await getVerifiedSession();
 
@@ -544,6 +637,7 @@ export async function getRecentActivityAction(filters = {}) {
 
   const limit = normalizeLimit(filters.limit);
   const action = normalizeAction(filters.action);
+  const entityType = normalizeEntityType(filters.entityType ?? filters.entity_type);
   const actorUserId = normalizeText(filters.actorUserId);
   const cursor = normalizeText(filters.cursor);
 
@@ -554,31 +648,49 @@ export async function getRecentActivityAction(filters = {}) {
       createIfMissing: !hasHouseholdInviteMetadata(user),
     });
     const supabase = await createClient();
-    let query = supabase
-      .from("recent_activity")
-      .select("*")
-      .order("created_at", { ascending: false })
-      .limit(limit + 1);
+    let recentRows = [];
 
-    if (action !== "all") {
-      query = query.eq("action", action);
+    if (entityType !== "task") {
+      let query = supabase
+        .from("recent_activity")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .limit(limit + 1);
+
+      if (action !== "all") {
+        query = query.eq("action", action);
+      }
+
+      if (entityType !== "all") {
+        query = query.eq("entity_type", entityType);
+      }
+
+      if (actorUserId) {
+        query = query.eq("actor_user_id", actorUserId);
+      }
+
+      if (cursor) {
+        query = query.lt("created_at", cursor);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      recentRows = data ?? [];
     }
 
-    if (actorUserId) {
-      query = query.eq("actor_user_id", actorUserId);
-    }
-
-    if (cursor) {
-      query = query.lt("created_at", cursor);
-    }
-
-    const { data, error } = await query;
-    if (error) throw error;
-
-    const rows = data ?? [];
+    const taskRows = await getTaskActivityRows({
+      householdId: household?.id,
+      action,
+      actorUserId,
+      entityType,
+      cursor,
+      limit,
+    });
+    const rows = mergeActivityRows(recentRows, taskRows);
+    const visibleRows = rows.slice(0, limit);
     const movedItems = await enrichMovedActivityItems(
       supabase,
-      rows.slice(0, limit)
+      visibleRows
     );
     const actorItems = await enrichActivityActors(movedItems, household?.id);
     const items = await enrichActivityImages(supabase, actorItems);

--- a/app/actions/tasks.js
+++ b/app/actions/tasks.js
@@ -1,0 +1,580 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getVerifiedSession } from "@/lib/verifiedSession";
+import { createAdminClient } from "@/utils/supabase/admin";
+import {
+  getHouseholdForUser,
+  hasHouseholdInviteMetadata,
+} from "@/utils/households";
+import {
+  TASK_STATUS,
+  calculateNextTaskDueDate,
+  canCompleteTask,
+  canCreateTask,
+  canDeleteTask,
+  canEditTask,
+  canReopenTask,
+  normalizeTaskId,
+  validateTaskPayload,
+} from "@/utils/tasks";
+
+function validationError(message) {
+  return { data: null, error: message };
+}
+
+function taskPayloadFromData(data = {}) {
+  const payload = {};
+
+  if ("title" in data) payload.title = data.title;
+  if ("description" in data) payload.description = data.description;
+  if ("assignedTo" in data) payload.assigned_to = data.assignedTo;
+  if ("locationId" in data) payload.location_id = data.locationId;
+  if ("status" in data) payload.status = data.status;
+  if ("priority" in data) payload.priority = data.priority;
+  if ("dueDate" in data) payload.due_date = data.dueDate;
+  if ("isRecurring" in data) payload.is_recurring = data.isRecurring;
+  if ("recurrenceType" in data) payload.recurrence_type = data.recurrenceType;
+  if ("recurrenceInterval" in data) {
+    payload.recurrence_interval = data.recurrenceInterval;
+  }
+
+  return payload;
+}
+
+function mapTaskRow(row) {
+  if (!row) return null;
+
+  return {
+    id: row.id,
+    householdId: row.household_id,
+    title: row.title,
+    description: row.description ?? null,
+    assignedTo: row.assigned_to ?? null,
+    createdBy: row.created_by ?? null,
+    locationId: row.location_id ?? null,
+    status: row.status,
+    priority: row.priority,
+    dueDate: row.due_date ?? null,
+    isRecurring: Boolean(row.is_recurring),
+    recurrenceType: row.recurrence_type ?? null,
+    recurrenceInterval: row.recurrence_interval ?? 1,
+    recurringParentTaskId: row.recurring_parent_task_id ?? null,
+    completedAt: row.completed_at ?? null,
+    completedBy: row.completed_by ?? null,
+    createdAt: row.created_at ?? null,
+    updatedAt: row.updated_at ?? null,
+  };
+}
+
+function revalidateTaskPaths() {
+  for (const path of ["/tasks", "/dashboard", "/activity"]) {
+    revalidatePath(path);
+  }
+}
+
+async function getTaskContext() {
+  const { user, error } = await getVerifiedSession();
+
+  if (error || !user?.id) {
+    return {
+      user: null,
+      household: null,
+      member: null,
+      error: error || "Your session has expired. Please log in again.",
+    };
+  }
+
+  const { household, member } = await getHouseholdForUser({
+    userId: user.id,
+    email: user.email,
+    createIfMissing: !hasHouseholdInviteMetadata(user),
+  });
+
+  if (!household?.id || !member?.household_id) {
+    return {
+      user,
+      household: null,
+      member: null,
+      error: "You are not a member of a household.",
+    };
+  }
+
+  return { user, household, member, error: null };
+}
+
+async function validateAssignedMember(admin, householdId, assignedTo) {
+  if (!assignedTo) return { data: null, error: null };
+
+  const { data, error } = await admin
+    .from("household_members")
+    .select("user_id, email, role")
+    .eq("household_id", householdId)
+    .eq("user_id", assignedTo)
+    .maybeSingle();
+
+  if (error) return { data: null, error: error.message || "Could not validate assignee." };
+  if (!data?.user_id) return { data: null, error: "Assignee must belong to your household." };
+
+  return { data, error: null };
+}
+
+async function validateTaskLocation(admin, householdId, locationId) {
+  if (!locationId) return { data: null, error: null };
+
+  const { data, error } = await admin
+    .from("locations")
+    .select("id, name, household_id")
+    .eq("id", locationId)
+    .maybeSingle();
+
+  if (error) return { data: null, error: error.message || "Could not validate location." };
+  if (!data?.id || String(data.household_id) !== String(householdId)) {
+    return { data: null, error: "Location must belong to your household." };
+  }
+
+  return { data, error: null };
+}
+
+async function getTaskForHousehold(admin, taskId, householdId) {
+  if (!taskId || !householdId) return { data: null, error: "Task is required." };
+
+  const { data, error } = await admin
+    .from("tasks")
+    .select("*")
+    .eq("id", taskId)
+    .eq("household_id", householdId)
+    .maybeSingle();
+
+  if (error) return { data: null, error: error.message || "Could not load task." };
+  if (!data?.id) return { data: null, error: "Task not found for this household." };
+
+  return { data, error: null };
+}
+
+async function recordTaskActivity({
+  admin,
+  household,
+  user,
+  task,
+  action,
+  changes = {},
+}) {
+  try {
+    const { error } = await admin.from("activity_events").insert({
+      household_id: household?.id ?? null,
+      actor_user_id: user?.id ?? null,
+      actor_email: user?.email ?? null,
+      entity_type: "task",
+      entity_id: task?.id ?? null,
+      action,
+      name_at_event: task?.title ?? null,
+      item_name: task?.title ?? null,
+      location_name: changes.locationName ?? null,
+      changes,
+    });
+    if (error) throw error;
+  } catch (err) {
+    console.error("recordTaskActivity error:", err);
+  }
+}
+
+async function validateTaskRelations(admin, householdId, payload) {
+  const assignedResult = await validateAssignedMember(
+    admin,
+    householdId,
+    payload.assigned_to
+  );
+  if (assignedResult.error) return assignedResult.error;
+
+  const locationResult = await validateTaskLocation(
+    admin,
+    householdId,
+    payload.location_id
+  );
+  if (locationResult.error) return locationResult.error;
+
+  return null;
+}
+
+export async function getTasksAction(filters = {}) {
+  const context = await getTaskContext();
+  if (context.error) {
+    return { data: { items: [] }, error: context.error };
+  }
+
+  try {
+    const admin = createAdminClient();
+    let query = admin
+      .from("tasks")
+      .select("*")
+      .eq("household_id", context.household.id)
+      .order("due_date", { ascending: true })
+      .order("created_at", { ascending: false });
+
+    const status = normalizeTaskId(filters.status);
+    const assignedTo = normalizeTaskId(filters.assignedTo ?? filters.assigned_to);
+    const locationId = normalizeTaskId(filters.locationId ?? filters.location_id);
+
+    if (status && status !== "all") query = query.eq("status", status);
+    if (assignedTo) query = query.eq("assigned_to", assignedTo);
+    if (locationId) query = query.eq("location_id", locationId);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return {
+      data: {
+        items: (data ?? []).map(mapTaskRow),
+      },
+      error: null,
+    };
+  } catch (err) {
+    return {
+      data: { items: [] },
+      error: err?.message || "Could not load tasks.",
+    };
+  }
+}
+
+export async function createTaskAction(values = {}) {
+  const validation = validateTaskPayload(values);
+  if (validation.error) return validationError(validation.error);
+
+  const context = await getTaskContext();
+  if (context.error) return validationError(context.error);
+  if (!canCreateTask(context.member)) {
+    return validationError("You do not have permission to create household tasks.");
+  }
+
+  const admin = createAdminClient();
+  const payload = {
+    ...taskPayloadFromData(validation.data),
+    household_id: context.household.id,
+    created_by: context.user.id,
+  };
+
+  const relationError = await validateTaskRelations(
+    admin,
+    context.household.id,
+    payload
+  );
+  if (relationError) return validationError(relationError);
+
+  try {
+    const { data, error } = await admin
+      .from("tasks")
+      .insert(payload)
+      .select("*")
+      .single();
+
+    if (error) throw error;
+
+    await recordTaskActivity({
+      admin,
+      household: context.household,
+      user: context.user,
+      task: data,
+      action: "added",
+      changes: {
+        assigned_to: data.assigned_to ?? null,
+        priority: data.priority,
+        due_date: data.due_date ?? null,
+        recurrence_type: data.recurrence_type ?? null,
+      },
+    });
+    revalidateTaskPaths();
+
+    return { data: mapTaskRow(data), error: null };
+  } catch (err) {
+    return validationError(err?.message || "Could not create task.");
+  }
+}
+
+export async function updateTaskAction(taskId, values = {}) {
+  const safeTaskId = normalizeTaskId(taskId);
+  const validation = validateTaskPayload(values, {
+    patch: true,
+    requireTitle: false,
+  });
+  if (validation.error) return validationError(validation.error);
+
+  const context = await getTaskContext();
+  if (context.error) return validationError(context.error);
+  if (!canEditTask(context.member)) {
+    return validationError("You do not have permission to edit household tasks.");
+  }
+
+  const admin = createAdminClient();
+  const existingResult = await getTaskForHousehold(
+    admin,
+    safeTaskId,
+    context.household.id
+  );
+  if (existingResult.error) return validationError(existingResult.error);
+
+  const payload = taskPayloadFromData(validation.data);
+  if ("status" in payload && payload.status !== existingResult.data.status) {
+    return validationError("Use the task completion controls to change completion state.");
+  }
+
+  if ("assigned_to" in payload) {
+    const assignedResult = await validateAssignedMember(
+      admin,
+      context.household.id,
+      payload.assigned_to
+    );
+    if (assignedResult.error) return validationError(assignedResult.error);
+  }
+
+  if ("location_id" in payload) {
+    const locationResult = await validateTaskLocation(
+      admin,
+      context.household.id,
+      payload.location_id
+    );
+    if (locationResult.error) return validationError(locationResult.error);
+  }
+
+  if (Object.keys(payload).length === 0) {
+    return { data: mapTaskRow(existingResult.data), error: null };
+  }
+
+  try {
+    const { data, error } = await admin
+      .from("tasks")
+      .update(payload)
+      .eq("id", safeTaskId)
+      .eq("household_id", context.household.id)
+      .select("*")
+      .single();
+
+    if (error) throw error;
+
+    await recordTaskActivity({
+      admin,
+      household: context.household,
+      user: context.user,
+      task: data,
+      action: "updated",
+      changes: payload,
+    });
+    revalidateTaskPaths();
+
+    return { data: mapTaskRow(data), error: null };
+  } catch (err) {
+    return validationError(err?.message || "Could not update task.");
+  }
+}
+
+async function createNextRecurringTask({ admin, householdId, task }) {
+  if (!task?.is_recurring || !task.recurrence_type || !task.due_date) {
+    return null;
+  }
+
+  const nextDueDate = calculateNextTaskDueDate(
+    task.due_date,
+    task.recurrence_type,
+    task.recurrence_interval
+  );
+  if (!nextDueDate) return null;
+
+  const parentTaskId = task.recurring_parent_task_id ?? task.id;
+  const { data: existingNext } = await admin
+    .from("tasks")
+    .select("id")
+    .eq("household_id", householdId)
+    .eq("recurring_parent_task_id", parentTaskId)
+    .eq("due_date", nextDueDate)
+    .maybeSingle();
+
+  if (existingNext?.id) return null;
+
+  const { data, error } = await admin
+    .from("tasks")
+    .insert({
+      household_id: task.household_id,
+      title: task.title,
+      description: task.description ?? null,
+      assigned_to: task.assigned_to ?? null,
+      created_by: task.created_by,
+      location_id: task.location_id ?? null,
+      status: TASK_STATUS.TODO,
+      priority: task.priority,
+      due_date: nextDueDate,
+      is_recurring: true,
+      recurrence_type: task.recurrence_type,
+      recurrence_interval: task.recurrence_interval ?? 1,
+      recurring_parent_task_id: parentTaskId,
+    })
+    .select("*")
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function completeTaskAction(taskId) {
+  const safeTaskId = normalizeTaskId(taskId);
+  const context = await getTaskContext();
+  if (context.error) return validationError(context.error);
+
+  const admin = createAdminClient();
+  const existingResult = await getTaskForHousehold(
+    admin,
+    safeTaskId,
+    context.household.id
+  );
+  if (existingResult.error) return validationError(existingResult.error);
+
+  if (!canCompleteTask(context.member, context.user.id, existingResult.data)) {
+    return validationError("You do not have permission to complete this task.");
+  }
+
+  if (existingResult.data.status === TASK_STATUS.COMPLETED) {
+    return {
+      data: { task: mapTaskRow(existingResult.data), nextTask: null },
+      error: null,
+    };
+  }
+
+  try {
+    const completedAt = new Date().toISOString();
+    const { data, error } = await admin
+      .from("tasks")
+      .update({
+        status: TASK_STATUS.COMPLETED,
+        completed_at: completedAt,
+        completed_by: context.user.id,
+      })
+      .eq("id", safeTaskId)
+      .eq("household_id", context.household.id)
+      .select("*")
+      .single();
+
+    if (error) throw error;
+
+    let nextTask = null;
+    try {
+      nextTask = await createNextRecurringTask({
+        admin,
+        householdId: context.household.id,
+        task: data,
+      });
+    } catch (err) {
+      console.error("createNextRecurringTask error:", err);
+    }
+
+    await recordTaskActivity({
+      admin,
+      household: context.household,
+      user: context.user,
+      task: data,
+      action: "completed",
+      changes: {
+        completed_at: completedAt,
+        next_due_date: nextTask?.due_date ?? null,
+      },
+    });
+    revalidateTaskPaths();
+
+    return {
+      data: {
+        task: mapTaskRow(data),
+        nextTask: mapTaskRow(nextTask),
+      },
+      error: null,
+    };
+  } catch (err) {
+    return validationError(err?.message || "Could not complete task.");
+  }
+}
+
+export async function reopenTaskAction(taskId) {
+  const safeTaskId = normalizeTaskId(taskId);
+  const context = await getTaskContext();
+  if (context.error) return validationError(context.error);
+
+  const admin = createAdminClient();
+  const existingResult = await getTaskForHousehold(
+    admin,
+    safeTaskId,
+    context.household.id
+  );
+  if (existingResult.error) return validationError(existingResult.error);
+
+  if (!canReopenTask(context.member, context.user.id, existingResult.data)) {
+    return validationError("You do not have permission to reopen this task.");
+  }
+
+  try {
+    const { data, error } = await admin
+      .from("tasks")
+      .update({
+        status: TASK_STATUS.TODO,
+        completed_at: null,
+        completed_by: null,
+      })
+      .eq("id", safeTaskId)
+      .eq("household_id", context.household.id)
+      .select("*")
+      .single();
+
+    if (error) throw error;
+
+    await recordTaskActivity({
+      admin,
+      household: context.household,
+      user: context.user,
+      task: data,
+      action: "updated",
+      changes: { status: TASK_STATUS.TODO, reopened: true },
+    });
+    revalidateTaskPaths();
+
+    return { data: mapTaskRow(data), error: null };
+  } catch (err) {
+    return validationError(err?.message || "Could not reopen task.");
+  }
+}
+
+export async function deleteTaskAction(taskId) {
+  const safeTaskId = normalizeTaskId(taskId);
+  const context = await getTaskContext();
+  if (context.error) return validationError(context.error);
+  if (!canDeleteTask(context.member)) {
+    return validationError("You do not have permission to delete household tasks.");
+  }
+
+  const admin = createAdminClient();
+  const existingResult = await getTaskForHousehold(
+    admin,
+    safeTaskId,
+    context.household.id
+  );
+  if (existingResult.error) return validationError(existingResult.error);
+
+  try {
+    const { error } = await admin
+      .from("tasks")
+      .delete()
+      .eq("id", safeTaskId)
+      .eq("household_id", context.household.id);
+
+    if (error) throw error;
+
+    await recordTaskActivity({
+      admin,
+      household: context.household,
+      user: context.user,
+      task: existingResult.data,
+      action: "deleted",
+      changes: { deleted: true },
+    });
+    revalidateTaskPaths();
+
+    return { data: { deletedId: safeTaskId }, error: null };
+  } catch (err) {
+    return validationError(err?.message || "Could not delete task.");
+  }
+}

--- a/components/app-shell/LazyTasksClients.jsx
+++ b/components/app-shell/LazyTasksClients.jsx
@@ -1,0 +1,10 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+export const LazyTasksPageClient = dynamic(
+  () => import("@/components/tasks/TasksPageClient"),
+  {
+    ssr: false,
+  }
+);

--- a/components/app-shell/Navigation.jsx
+++ b/components/app-shell/Navigation.jsx
@@ -44,6 +44,7 @@ import {
   LuShoppingBasket,
   LuTags,
   LuCircleUser,
+  LuClipboardCheck,
   LuUsers,
   LuWarehouse,
 } from "react-icons/lu";
@@ -56,6 +57,7 @@ const navItems = [
   { href: "/categories", label: "Categories", icon: FaTags },
   { href: "/items", label: "Items", icon: FaBoxOpen },
   { href: "/shopping-list", label: "Shopping List", icon: FaShoppingBasket },
+  { href: "/tasks", label: "Tasks", icon: LuClipboardCheck },
   { href: "/profile", label: "Profile", icon: FaUserCircle },
 ];
 
@@ -133,6 +135,8 @@ async function fetchAttentionCounts() {
     "@/utils/supabase/client"
   );
   const supabase = createBrowserSupabaseClient();
+  const taskAttentionCountPromise = fetchTaskAttentionCount(supabase);
+
   try {
     const { data, error } = await supabase.rpc(
       "wherekeep_inventory_summary_counts",
@@ -151,6 +155,7 @@ async function fetchAttentionCounts() {
         categoriesCount: Number(row.categories_count ?? 0),
         itemsCount: Number(row.items_count ?? 0),
         lowStockCount: Number(row.low_stock_count ?? 0),
+        tasksAttentionCount: await taskAttentionCountPromise,
         summaryCountsLoaded: true,
       };
     }
@@ -220,7 +225,31 @@ async function fetchAttentionCounts() {
     storageAreasCount: storageAreasCount ?? 0,
     categoriesCount: categoriesCount ?? 0,
     itemsCount: itemsCount ?? 0,
+    tasksAttentionCount: await taskAttentionCountPromise,
   };
+}
+
+async function fetchTaskAttentionCount(supabase) {
+  const today = toDateString(new Date());
+
+  try {
+    const { count = 0, error } = await supabase
+      .from("tasks")
+      .select("id", { count: "exact", head: true })
+      .neq("status", "completed")
+      .not("due_date", "is", null)
+      .lte("due_date", today);
+
+    if (error) {
+      logNavigationWarning("Navigation task counts unavailable.", getErrorMessage(error));
+      return 0;
+    }
+
+    return count ?? 0;
+  } catch (err) {
+    logNavigationWarning("Navigation task counts failed.", getErrorMessage(err));
+    return 0;
+  }
 }
 
 function MobileTopBar({ attentionCount, onOpenMenu, onOpenAttention }) {
@@ -319,7 +348,6 @@ const desktopSidebarSections = [
     title: "HOME",
     items: [
       { href: "/dashboard", label: "Overview", icon: LuHouse },
-      { href: "/activity", label: "Activities", icon: LuActivity },
       { href: "/locations", label: "Locations", icon: LuMapPin, countKey: "locationsCount" },
       { href: "/areas", label: "Storage Areas", icon: LuWarehouse, countKey: "storageAreasCount" },
       { href: "/categories", label: "Categories", icon: LuTags, countKey: "categoriesCount" },
@@ -330,6 +358,8 @@ const desktopSidebarSections = [
         icon: LuShoppingBasket,
         countKey: "shoppingListNeededItems",
       },
+      { href: "/tasks", label: "Tasks", icon: LuClipboardCheck, countKey: "tasksAttentionCount" },
+      { href: "/activity", label: "Activities", icon: LuActivity },
     ],
   },
   {
@@ -682,8 +712,9 @@ export default function Navigation({
   const expiringSoonCount = liveAttentionCounts.expiringSoonCount ?? 0;
   const shoppingListNeededItems =
     liveAttentionCounts.shoppingListNeededItems ?? 0;
+  const taskAttentionCount = liveAttentionCounts.tasksAttentionCount ?? 0;
   const attentionCount =
-    expiredCount + expiringSoonCount + shoppingListNeededItems;
+    expiredCount + expiringSoonCount + shoppingListNeededItems + taskAttentionCount;
   const bottomNavItemClass = (isActive = false) =>
     cx(
       "flex min-h-14 flex-col items-center justify-center gap-1 rounded-2xl border transition",
@@ -1060,6 +1091,7 @@ export default function Navigation({
     attentionCounts.storageAreasCount,
     attentionCounts.categoriesCount,
     attentionCounts.itemsCount,
+    attentionCounts.tasksAttentionCount,
     attentionCounts.memberCount,
   ]);
 
@@ -1308,6 +1340,7 @@ export default function Navigation({
           expiredCount={expiredCount}
           expiringSoonCount={expiringSoonCount}
           shoppingListItems={shoppingListNeededItems}
+          taskAttentionCount={taskAttentionCount}
         />
       )}
 

--- a/components/app-shell/NavigationOverlays.jsx
+++ b/components/app-shell/NavigationOverlays.jsx
@@ -11,6 +11,7 @@ import {
   FaShoppingBasket,
   FaSignOutAlt,
   FaSpinner,
+  FaTasks,
   FaTags,
   FaTimes,
   FaUserCircle,
@@ -88,6 +89,12 @@ const mobileMenuSections = [
   {
     title: "Tools",
     items: [
+      {
+        href: "/tasks",
+        label: "Tasks",
+        icon: FaTasks,
+        countKey: "tasksAttentionCount",
+      },
       {
         href: "/shopping-list",
         label: "Shopping List",
@@ -280,10 +287,14 @@ export function AttentionSheet({
   expiredCount,
   expiringSoonCount,
   shoppingListItems,
+  taskAttentionCount = 0,
 }) {
   const { isVisible, shouldRender } = useTransitionMount(isOpen, 240);
   const hasAttention =
-    expiredCount > 0 || expiringSoonCount > 0 || shoppingListItems > 0;
+    expiredCount > 0 ||
+    expiringSoonCount > 0 ||
+    shoppingListItems > 0 ||
+    taskAttentionCount > 0;
   const anchoredStyle = anchor
     ? {
         top: `${anchor.top}px`,
@@ -333,7 +344,7 @@ export function AttentionSheet({
                   </h2>
                   <p className="mt-1 text-sm leading-5 text-slate-500">
                     {hasAttention
-                      ? "Items that need a quick look."
+                      ? "Household updates that need a quick look."
                       : "Everything looks good."}
                   </p>
                 </div>
@@ -386,11 +397,23 @@ export function AttentionSheet({
                     <span className="font-semibold text-[var(--stocksense-brand)]">Open</span>
                   </Link>
                 )}
+                {taskAttentionCount > 0 && (
+                  <Link
+                    href="/tasks"
+                    onClick={onClose}
+                    className="flex min-h-11 items-center justify-between gap-3 rounded-2xl border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] px-3 py-2 text-sm font-medium text-[var(--stocksense-brand)]"
+                  >
+                    <span>
+                      {taskAttentionCount} task{taskAttentionCount === 1 ? "" : "s"} overdue or due today
+                    </span>
+                    <span className="font-semibold">Open</span>
+                  </Link>
+                )}
               </div>
             ) : (
               <div className="p-4">
                 <div className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-500">
-                  No expired items, urgent expirations, or needed shopping list items.
+                  No expired items, urgent expirations, needed shopping list items, or tasks due today.
                 </div>
               </div>
             )}

--- a/components/app-shell/authenticatedShellState.js
+++ b/components/app-shell/authenticatedShellState.js
@@ -43,6 +43,29 @@ function normalizeSummaryCounts(row) {
   };
 }
 
+async function getNavigationTaskCounts(supabase) {
+  const today = toDateString(new Date());
+
+  try {
+    const { count = 0, error } = await supabase
+      .from("tasks")
+      .select("id", { count: "exact", head: true })
+      .neq("status", "completed")
+      .not("due_date", "is", null)
+      .lte("due_date", today);
+
+    if (error) {
+      logNavigationWarning("Navigation task counts unavailable.", getErrorMessage(error));
+      return { tasksAttentionCount: 0 };
+    }
+
+    return { tasksAttentionCount: count ?? 0 };
+  } catch (err) {
+    logNavigationWarning("Navigation task counts failed.", getErrorMessage(err));
+    return { tasksAttentionCount: 0 };
+  }
+}
+
 async function getNavigationAttentionCounts(supabase, withinDays = 3) {
   try {
     const { data, error } = await supabase.rpc(
@@ -220,6 +243,7 @@ export const getAuthenticatedAppShellState = cache(async function getAuthenticat
     shoppingListItemsCount: 0,
     lowStockCount: 0,
     summaryCountsLoaded: false,
+    tasksAttentionCount: 0,
     memberCount: 0,
     inviteCount: 0,
   };
@@ -289,9 +313,14 @@ export const getAuthenticatedAppShellState = cache(async function getAuthenticat
 
     try {
       if (!supabase) supabase = await createClient();
+      const [inventoryCounts, taskCounts] = await Promise.all([
+        getNavigationAttentionCounts(supabase),
+        getNavigationTaskCounts(supabase),
+      ]);
       attentionCounts = {
         ...attentionCounts,
-        ...(await getNavigationAttentionCounts(supabase)),
+        ...inventoryCounts,
+        ...taskCounts,
       };
     } catch (err) {
       logNavigationWarning("Navigation attention counts unavailable.", getErrorMessage(err));

--- a/components/dashboard/MobileDashboardHome.jsx
+++ b/components/dashboard/MobileDashboardHome.jsx
@@ -8,6 +8,7 @@ import {
   FaBell,
   FaBoxOpen,
   FaCamera,
+  FaClipboardCheck,
   FaMapMarkedAlt,
   FaMapMarkerAlt,
   FaPlus,
@@ -85,6 +86,7 @@ function activityActionLabel(row) {
   }
 
   if (action === "added") return "Added";
+  if (action === "completed") return "Completed";
   if (action === "deleted") return "Removed";
   if (action === "moved") return "Moved";
   if (action === "updated") return "Updated";
@@ -95,6 +97,7 @@ function activityActionClass(row) {
   const action = String(row?.action || "").toLowerCase();
   const classes = {
     added: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200",
+    completed: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200",
     updated: "bg-amber-50 text-amber-700 ring-1 ring-amber-200",
     deleted: "bg-rose-50 text-rose-700 ring-1 ring-rose-200",
     moved: "bg-sky-50 text-sky-700 ring-1 ring-sky-200",
@@ -109,6 +112,7 @@ function activityTone(row) {
   if (entity === "location") return "location";
   if (entity === "storage_area") return "area";
   if (entity === "category") return "category";
+  if (entity === "task") return "brand";
   if (entity === "shopping_list_item") return "shopping";
   return "item";
 }
@@ -119,6 +123,7 @@ function activityIcon(row) {
   if (entity === "location") return FaMapMarkedAlt;
   if (entity === "storage_area") return FaWarehouse;
   if (entity === "category") return FaTags;
+  if (entity === "task") return FaClipboardCheck;
   if (entity === "shopping_list_item") return FaShoppingBasket;
   return FaBoxOpen;
 }

--- a/components/dashboard/RecentActivity.jsx
+++ b/components/dashboard/RecentActivity.jsx
@@ -6,6 +6,7 @@ import { motion } from '@/components/ui/MotionLite';
 import {
   FaBolt,
   FaBoxOpen,
+  FaClipboardCheck,
   FaMapMarkedAlt,
   FaShoppingBasket,
   FaTags,
@@ -23,9 +24,19 @@ const ALL_FILTER = 'all';
 const ACTION_OPTIONS = [
   { value: ALL_FILTER, label: 'All activity' },
   { value: 'added', label: 'Added' },
+  { value: 'completed', label: 'Completed' },
   { value: 'deleted', label: 'Removed' },
   { value: 'moved', label: 'Moved' },
   { value: 'updated', label: 'Updated' },
+];
+const ENTITY_OPTIONS = [
+  { value: ALL_FILTER, label: 'All types' },
+  { value: 'location', label: 'Locations' },
+  { value: 'storage_area', label: 'Storage Areas' },
+  { value: 'category', label: 'Categories' },
+  { value: 'item', label: 'Items' },
+  { value: 'shopping_list_item', label: 'Shopping List' },
+  { value: 'task', label: 'Tasks' },
 ];
 
 function label(key) {
@@ -114,6 +125,14 @@ function entityName(row) {
       'changes.name.to',
       'changes.snapshot.name',
       'changes.from_deleted_item.name',
+    ],
+    task: [
+      'item_name',
+      'name_at_event',
+      'changes.title.to',
+      'changes.title.from',
+      'changes.name.to',
+      'changes.name.from',
     ],
   };
 
@@ -251,6 +270,14 @@ function ActionBadge({ action }) {
         color: 'var(--entity-category-accent)',
       },
     },
+    completed: {
+      text: 'Completed',
+      style: {
+        backgroundColor: 'color-mix(in oklab, var(--entity-category-accent) 12%, white)',
+        borderColor: 'color-mix(in oklab, var(--entity-category-accent) 28%, white)',
+        color: 'var(--entity-category-accent)',
+      },
+    },
     updated: {
       text: 'Updated',
       style: {
@@ -296,6 +323,8 @@ function entityIcon(entity) {
       return <FaWarehouse className="h-4 w-4 text-[var(--stocksense-brand)]" />;
     case 'category':
       return <FaTags className="h-4 w-4 text-[var(--stocksense-brand)]" />;
+    case 'task':
+      return <FaClipboardCheck className="h-4 w-4 text-[var(--stocksense-brand)]" />;
     case 'shopping_list_item':
       return <FaShoppingBasket className="h-4 w-4 text-[var(--stocksense-brand)]" />;
     default:
@@ -368,6 +397,15 @@ function detailLine(row) {
     }
 
     return `Shopping list activity | ${formatChanges(row.changes)}`;
+  }
+
+  if (entity === 'task') {
+    if (action === 'added') return 'Created household task.';
+    if (action === 'completed') return 'Completed task.';
+    if (action === 'deleted') return 'Removed task.';
+    if (row.changes?.reopened) return 'Reopened task.';
+    if (action === 'updated') return 'Updated task.';
+    return formatChanges(row.changes);
   }
 
   if (action === 'deleted') {
@@ -471,6 +509,7 @@ export default function RecentActivity({
     isFullView ? items : items.slice(0, DASHBOARD_ACTIVITY_LIMIT)
   );
   const [actorUserId, setActorUserId] = useState(ALL_FILTER);
+  const [entityType, setEntityType] = useState(ALL_FILTER);
   const [action, setAction] = useState(ALL_FILTER);
   const [cursor, setCursor] = useState(initialCursor);
   const [hasMore, setHasMore] = useState(initialHasMore);
@@ -505,7 +544,13 @@ export default function RecentActivity({
       return;
     }
 
-    if (actorUserId !== ALL_FILTER || action !== ALL_FILTER) return;
+    if (
+      actorUserId !== ALL_FILTER ||
+      entityType !== ALL_FILTER ||
+      action !== ALL_FILTER
+    ) {
+      return;
+    }
 
     setActivityItems(items);
     setCursor(initialCursor);
@@ -514,6 +559,7 @@ export default function RecentActivity({
   }, [
     action,
     actorUserId,
+    entityType,
     initialCursor,
     initialError,
     initialHasMore,
@@ -523,6 +569,7 @@ export default function RecentActivity({
 
   const loadActivity = useCallback(async function loadActivity({
     nextActorUserId = actorUserId,
+    nextEntityType = entityType,
     nextAction = action,
     mode = 'replace',
   } = {}) {
@@ -542,6 +589,7 @@ export default function RecentActivity({
           ? {
               limit: PAGE_SIZE,
               action: nextAction,
+              entityType: nextEntityType,
               actorUserId:
                 nextActorUserId === ALL_FILTER ? null : nextActorUserId,
               cursor: append ? cursor : null,
@@ -570,7 +618,7 @@ export default function RecentActivity({
       setIsRefreshing(false);
       setIsLoadingMore(false);
     }
-  }, [action, actorUserId, cursor, isFullView]);
+  }, [action, actorUserId, cursor, entityType, isFullView]);
 
   function handleActorChange(value) {
     const nextActorUserId = String(value || ALL_FILTER);
@@ -582,6 +630,12 @@ export default function RecentActivity({
     const nextAction = String(value || ALL_FILTER);
     setAction(nextAction);
     void loadActivity({ nextAction, mode: 'replace' });
+  }
+
+  function handleEntityTypeChange(value) {
+    const nextEntityType = String(value || ALL_FILTER);
+    setEntityType(nextEntityType);
+    void loadActivity({ nextEntityType, mode: 'replace' });
   }
 
   useEffect(() => {
@@ -620,7 +674,7 @@ export default function RecentActivity({
         {isFullView ? (
           <div
             className={`mt-4 grid gap-3 ${
-              showUserFilter ? 'sm:grid-cols-2' : 'sm:grid-cols-1'
+              showUserFilter ? 'sm:grid-cols-3' : 'sm:grid-cols-2'
             }`}
           >
             {showUserFilter ? (
@@ -644,6 +698,20 @@ export default function RecentActivity({
                 ]}
               />
             ) : null}
+
+            <NativeSelect
+              aria-label="Filter recent activity by type"
+              label={
+                <span className="inline-flex items-center gap-1.5">
+                  <FaBoxOpen className="h-3.5 w-3.5 text-[var(--stocksense-brand)]" />
+                  Activity type
+                </span>
+              }
+              value={entityType}
+              onChange={handleEntityTypeChange}
+              disabled={isRefreshing}
+              options={ENTITY_OPTIONS}
+            />
 
             <NativeSelect
               aria-label="Filter recent activity by action"

--- a/components/dashboard/TasksDueCard.jsx
+++ b/components/dashboard/TasksDueCard.jsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { LuClipboardCheck, LuClock3, LuMapPin } from "react-icons/lu";
+import { parsePantryDate } from "@/utils/pantry/date";
+
+function formatDueDate(value) {
+  const date = parsePantryDate(value);
+  if (!date) return "No due date";
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function TasksDueCard({ tasks = [], dueTodayCount = 0 }) {
+  const visibleTasks = tasks.slice(0, 5);
+
+  return (
+    <section className="rounded-2xl border border-white/70 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-950">Tasks</h2>
+          <p className="mt-1 text-sm leading-5 text-gray-500">
+            {dueTodayCount.toLocaleString()} due today
+          </p>
+        </div>
+        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] text-[var(--stocksense-brand)]">
+          <LuClipboardCheck className="h-4 w-4" />
+        </span>
+      </div>
+
+      {visibleTasks.length ? (
+        <ul className="mt-5 grid gap-2">
+          {visibleTasks.map((task) => (
+            <li
+              key={task.id}
+              className="rounded-2xl border border-gray-100 bg-gray-50/40 px-3 py-2.5"
+            >
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full border border-gray-300 bg-white">
+                  <span className="h-2 w-2 rounded-full bg-[var(--stocksense-brand)]" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold text-gray-900" title={task.title}>
+                    {task.title}
+                  </p>
+                  <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-gray-500">
+                    <span className="inline-flex items-center gap-1">
+                      <LuClock3 className="h-3 w-3 text-[var(--stocksense-brand)]" />
+                      {formatDueDate(task.dueDate)}
+                    </span>
+                    {task.locationName ? (
+                      <span className="inline-flex min-w-0 items-center gap-1">
+                        <LuMapPin className="h-3 w-3 shrink-0 text-[var(--stocksense-brand)]" />
+                        <span className="truncate">{task.locationName}</span>
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-5 rounded-2xl border border-dashed border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)]/60 p-4 text-sm text-gray-600">
+          No urgent tasks right now.
+        </div>
+      )}
+
+      <Link
+        href="/tasks"
+        className="mt-4 inline-flex h-10 w-full items-center justify-center rounded-2xl border border-[var(--stocksense-brand-border)] bg-white px-4 text-sm font-semibold text-[var(--stocksense-brand)] transition hover:bg-[var(--stocksense-brand-soft)]"
+      >
+        View all tasks
+      </Link>
+    </section>
+  );
+}

--- a/components/items/ItemPageClient.jsx
+++ b/components/items/ItemPageClient.jsx
@@ -2629,7 +2629,7 @@ export default function ItemsPageClient({
         secondaryConfirmLabel={
           deleteDialog.mode === "single" ? "Move to shopping list" : null
         }
-        secondaryConfirmClassName="rounded-xl border border-emerald-200 bg-emerald-50 text-emerald-700"
+        secondaryConfirmClassName="rounded-xl border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand)] text-white"
         title={
           deleteDialog.mode === "bulk"
             ? `Delete ${deleteDialog.payload?.count ?? 0} items?`

--- a/components/marketing/LandingPage.jsx
+++ b/components/marketing/LandingPage.jsx
@@ -8,10 +8,16 @@ import {
 } from 'react-icons/fa';
 import {
   LuChevronDown,
+  LuCalendarClock,
+  LuCircleCheck,
+  LuClipboardCheck,
+  LuClock3,
+  LuFlag,
   LuLayers3,
   LuMapPin,
   LuPackage,
   LuPlus,
+  LuRepeat2,
   LuSearch,
   LuSearchCheck,
   LuUsers,
@@ -65,6 +71,13 @@ const familyBenefits = [
   'Owners manage roles and billing',
   'Editors can add and organize items',
   'Viewers can search without editing',
+];
+
+const taskBenefits = [
+  'Create tasks and recurring chores',
+  'Assign tasks to household members',
+  'Set due dates and priorities',
+  'See what is due today or coming up',
 ];
 
 const conversionStats = [
@@ -160,6 +173,69 @@ const hierarchyJourneys = [
       { label: 'Batteries', icon: LuPackage },
     ],
   },
+];
+
+const taskPreviewTabs = ['All', 'My Tasks', 'Due Today', 'Upcoming', 'Completed'];
+
+const taskPreviewSections = [
+  {
+    label: 'Today',
+    tasks: [
+      {
+        title: 'Take out the trash',
+        location: 'Kitchen',
+        assignee: 'Joseph',
+        initials: 'J',
+        due: 'Today',
+        priority: 'High',
+        recurring: true,
+      },
+      {
+        title: 'Clean the kitchen',
+        location: 'Kitchen',
+        assignee: 'Leah',
+        initials: 'L',
+        due: 'Today',
+        priority: 'Medium',
+      },
+      {
+        title: 'Water the plants',
+        location: 'Living Room',
+        assignee: 'Ava',
+        initials: 'A',
+        due: 'Today',
+        priority: 'Low',
+      },
+    ],
+  },
+  {
+    label: 'Upcoming',
+    tasks: [
+      {
+        title: 'Replace HVAC air filter',
+        location: 'Hallway Closet',
+        assignee: 'Joseph',
+        initials: 'J',
+        due: 'Aug 25',
+        priority: 'High',
+        recurring: true,
+      },
+      {
+        title: 'Organize the pantry',
+        location: 'Pantry',
+        assignee: 'Leah',
+        initials: 'L',
+        due: 'Aug 30',
+        priority: 'Medium',
+      },
+    ],
+  },
+];
+
+const mobileTaskPreview = [
+  taskPreviewSections[0].tasks[0],
+  taskPreviewSections[0].tasks[1],
+  taskPreviewSections[1].tasks[0],
 ];
 
 const faqs = [
@@ -276,6 +352,256 @@ function SectionHeader({ eyebrow, title, description }) {
         </p>
       )}
     </div>
+  );
+}
+
+function TaskPreviewPriority({ priority }) {
+  const tone =
+    priority === 'High'
+      ? 'border-rose-200 bg-rose-50 text-rose-700'
+      : priority === 'Low'
+        ? 'border-slate-200 bg-slate-50 text-slate-600'
+        : 'border-amber-200 bg-amber-50 text-amber-700';
+
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-lg border px-2 py-1 text-[11px] font-semibold ${tone}`}>
+      <LuFlag className="h-3 w-3" />
+      {priority}
+    </span>
+  );
+}
+
+function TaskPreviewAvatar({ initials, assignee }) {
+  return (
+    <span
+      className="grid h-7 w-7 shrink-0 place-items-center rounded-full border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] text-[11px] font-bold text-[var(--stocksense-brand)]"
+      title={assignee}
+    >
+      {initials}
+    </span>
+  );
+}
+
+function TaskPreviewRow({ task }) {
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white px-3 py-3 shadow-sm">
+      <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3">
+        <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-full border border-gray-300 bg-white">
+          <LuCircleCheck className="h-3.5 w-3.5 text-transparent" />
+        </span>
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <p className="truncate text-sm font-semibold text-gray-950">
+              {task.title}
+            </p>
+            {task.recurring ? (
+              <span className="grid h-5 w-5 shrink-0 place-items-center rounded-full border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] text-[var(--stocksense-brand)]">
+                <LuRepeat2 className="h-3 w-3" />
+              </span>
+            ) : null}
+          </div>
+          <div className="mt-2 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <LuMapPin className="h-3.5 w-3.5 shrink-0 text-[var(--stocksense-brand)]" />
+              <span className="truncate">{task.location}</span>
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <LuClock3 className="h-3.5 w-3.5 shrink-0 text-[var(--stocksense-brand)]" />
+              {task.due}
+            </span>
+          </div>
+        </div>
+        <TaskPreviewPriority priority={task.priority} />
+      </div>
+      <div className="mt-3 flex min-w-0 items-center gap-2 border-t border-gray-100 pt-3">
+        <TaskPreviewAvatar initials={task.initials} assignee={task.assignee} />
+        <span className="min-w-0 truncate text-xs font-semibold text-gray-600">
+          {task.assignee}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function TaskDesktopPreview() {
+  return (
+    <div className="relative rounded-3xl border border-gray-200 bg-white p-4 shadow-2xl">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="grid h-9 w-9 place-items-center rounded-xl border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] text-[var(--stocksense-brand)]">
+              <LuClipboardCheck className="h-4 w-4" />
+            </span>
+            <div>
+              <h3 className="text-lg font-semibold text-gray-950">Tasks</h3>
+              <p className="text-xs text-gray-500">3 due today</p>
+            </div>
+          </div>
+        </div>
+        <span className="hidden rounded-xl bg-[var(--stocksense-brand)] px-3 py-2 text-xs font-semibold text-white sm:inline-flex">
+          New Task
+        </span>
+      </div>
+
+      <div className="mt-4 flex max-w-full gap-2 overflow-hidden">
+        {taskPreviewTabs.map((tab, index) => (
+          <span
+            key={tab}
+            className={`shrink-0 rounded-xl px-3 py-2 text-xs font-semibold ${
+              index === 0
+                ? 'bg-[var(--stocksense-brand)] text-white'
+                : 'border border-gray-200 bg-white text-gray-600'
+            }`}
+          >
+            {tab}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-4 grid gap-4">
+        {taskPreviewSections.map((section) => (
+          <div key={section.label} className="grid gap-2.5">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-gray-400">
+                {section.label}
+              </p>
+              <span className="text-xs font-semibold text-[var(--stocksense-brand)]">
+                {section.tasks.length}
+              </span>
+            </div>
+            <div className="grid gap-2.5">
+              {section.tasks.map((task) => (
+                <TaskPreviewRow key={task.title} task={task} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TaskMobilePreview() {
+  return (
+    <div className="absolute -bottom-6 right-0 hidden w-[13.5rem] rounded-[1.75rem] border border-gray-900 bg-gray-950 p-1.5 shadow-2xl md:block lg:-right-4">
+      <div className="overflow-hidden rounded-[1.35rem] bg-white p-3">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-base font-semibold text-gray-950">Tasks</h3>
+          <span className="grid h-8 w-8 place-items-center rounded-full bg-[var(--stocksense-brand)] text-sm font-semibold text-white">
+            +
+          </span>
+        </div>
+        <div className="mt-3 flex gap-1.5 overflow-hidden">
+          {['All', 'Mine', 'Today'].map((tab, index) => (
+            <span
+              key={tab}
+              className={`shrink-0 rounded-lg px-2 py-1 text-[10px] font-semibold ${
+                index === 0
+                  ? 'bg-[var(--stocksense-brand)] text-white'
+                  : 'border border-gray-200 text-gray-500'
+              }`}
+            >
+              {tab}
+            </span>
+          ))}
+        </div>
+        <div className="mt-3 grid gap-2">
+          {mobileTaskPreview.map((task) => (
+            <div
+              key={task.title}
+              className="rounded-xl border border-gray-100 bg-gray-50/70 p-2"
+            >
+              <div className="flex min-w-0 items-start gap-2">
+                <span className="mt-0.5 h-4 w-4 shrink-0 rounded-full border border-gray-300 bg-white" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[11px] font-semibold text-gray-950">
+                    {task.title}
+                  </p>
+                  <p className="mt-0.5 truncate text-[10px] text-gray-500">
+                    {task.location} / {task.due}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <TaskPreviewAvatar initials={task.initials} assignee={task.assignee} />
+                  <span className="truncate text-[10px] font-semibold text-gray-600">
+                    {task.assignee}
+                  </span>
+                </div>
+                <span className="shrink-0 text-[10px] font-semibold text-[var(--stocksense-brand)]">
+                  {task.priority}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TasksChoresSection() {
+  return (
+    <section className="border-y border-gray-200 bg-gray-50">
+      <div className="mx-auto grid max-w-6xl gap-9 px-5 py-14 lg:grid-cols-[0.86fr_1.14fr] lg:items-center">
+        <div>
+          <div className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--stocksense-brand)]">
+            NEW &middot; TASKS & CHORES
+          </div>
+          <h2 className="text-2xl font-semibold tracking-tight text-gray-900 sm:text-3xl lg:text-4xl lg:leading-tight">
+            Stay on top of what needs to get done.
+          </h2>
+          <p className="mt-3 max-w-xl text-sm leading-6 text-gray-600 sm:text-base">
+            Assign tasks, set due dates, and keep your household running
+            smoothly together.
+          </p>
+          <div className="mt-5 grid gap-2.5">
+            {taskBenefits.map((benefit) => (
+              <div
+                key={benefit}
+                className="flex items-center gap-2 text-sm font-medium text-gray-700"
+              >
+                <span className="grid h-5 w-5 shrink-0 place-items-center rounded-full bg-white text-[var(--stocksense-brand)] shadow-sm">
+                  <FaCheck className="h-2.5 w-2.5" aria-hidden="true" />
+                </span>
+                <span>{benefit}</span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/signup"
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--stocksense-brand)] px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:brightness-95"
+              aria-label="Get started free with WhereKeep tasks and chores"
+            >
+              Get Started Free <FaArrowRight className="h-3.5 w-3.5" />
+            </Link>
+            <Link
+              href="#pricing"
+              className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-5 py-3 text-sm font-semibold text-gray-700 shadow-sm transition hover:bg-gray-50"
+            >
+              Compare plans
+            </Link>
+          </div>
+        </div>
+
+        <div
+          className="relative mx-auto w-full max-w-2xl rounded-[2rem] border border-white/80 bg-white/70 p-3 shadow-[0_24px_70px_rgba(14,116,136,0.10)] sm:p-4"
+          role="img"
+          aria-label="Preview of household tasks and chores in WhereKeep"
+        >
+          <div className="absolute left-5 top-5 hidden items-center gap-2 rounded-full border border-[var(--stocksense-brand-border)] bg-white px-3 py-1 text-xs font-semibold text-[var(--stocksense-brand)] shadow-sm sm:flex">
+            <LuCalendarClock className="h-3.5 w-3.5" />
+            Due today
+          </div>
+          <div className="pt-0 sm:pt-8">
+            <TaskDesktopPreview />
+          </div>
+          <TaskMobilePreview />
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -586,6 +912,8 @@ export default function LandingPage() {
           </div>
         </div>
       </section>
+
+      <TasksChoresSection />
 
       <section className="bg-white">
         <div className="mx-auto max-w-6xl px-5 py-14">

--- a/components/tasks/TasksPageClient.jsx
+++ b/components/tasks/TasksPageClient.jsx
@@ -1,0 +1,1062 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  LuCalendarClock,
+  LuCircleCheck,
+  LuCircleUser,
+  LuClipboardCheck,
+  LuClock3,
+  LuFilter,
+  LuFlag,
+  LuMapPin,
+  LuPlus,
+  LuRepeat2,
+} from "react-icons/lu";
+import {
+  completeTaskAction,
+  createTaskAction,
+  deleteTaskAction,
+  reopenTaskAction,
+  updateTaskAction,
+} from "@/app/actions/tasks";
+import NativeButton from "@/components/ui/NativeButton";
+import NativeDatePicker from "@/components/ui/NativeDatePicker";
+import NativeDropdown from "@/components/ui/NativeDropdown";
+import NativeInput from "@/components/ui/NativeInput";
+import ConfirmDeleteModal from "@/components/modals/ConfirmDeleteModal";
+import { cx } from "@/components/ui/classNames";
+import { emitInventoryChange } from "@/utils/clientEvents";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@/components/ui/NativeModal";
+import NativeSelect from "@/components/ui/NativeSelect";
+import {
+  TASK_PRIORITY,
+  TASK_RECURRENCE,
+  TASK_SORT,
+  TASK_STATUS,
+  canCreateTask,
+  canDeleteTask,
+  canEditTask,
+  canCompleteTask,
+  groupTasksByDate,
+  isTaskDueToday,
+  isTaskOverdue,
+  isTaskUpcoming,
+  sortTasks,
+  summarizeTasks,
+} from "@/utils/tasks";
+import { parsePantryDate } from "@/utils/pantry/date";
+
+const TABS = [
+  { value: "all", label: "All", mobileLabel: "All" },
+  { value: "assigned", label: "Assigned to Me", mobileLabel: "Mine" },
+  { value: "created", label: "Created by Me", hideOnMobile: true },
+  { value: "unassigned", label: "Unassigned", hideOnMobile: true },
+  { value: "due_today", label: "Due Today", mobileLabel: "Due Today", mobileOnly: true },
+  { value: "completed", label: "Completed", mobileLabel: "Completed" },
+];
+
+const MOBILE_TAB_OPTIONS = TABS.map((tab) => ({
+  value: tab.value,
+  label: tab.mobileLabel ?? tab.label,
+}));
+
+const PRIORITY_OPTIONS = [
+  { value: TASK_PRIORITY.LOW, label: "Low" },
+  { value: TASK_PRIORITY.MEDIUM, label: "Medium" },
+  { value: TASK_PRIORITY.HIGH, label: "High" },
+];
+
+const SORT_OPTIONS = [
+  { value: TASK_SORT.DUE_DATE, label: "Due date" },
+  { value: TASK_SORT.NEWEST, label: "Newest" },
+  { value: TASK_SORT.OLDEST, label: "Oldest" },
+  { value: TASK_SORT.PRIORITY, label: "Priority" },
+  { value: TASK_SORT.ALPHABETICAL, label: "Alphabetical" },
+];
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "Any status" },
+  { value: TASK_STATUS.TODO, label: "To do" },
+  { value: TASK_STATUS.IN_PROGRESS, label: "In progress" },
+  { value: TASK_STATUS.COMPLETED, label: "Completed" },
+];
+
+const DUE_DATE_FILTER_OPTIONS = [
+  { value: "all", label: "Any due date" },
+  { value: "overdue", label: "Overdue" },
+  { value: "today", label: "Due today" },
+  { value: "upcoming", label: "Upcoming" },
+  { value: "none", label: "No due date" },
+];
+
+const RECURRING_FILTER_OPTIONS = [
+  { value: "all", label: "Any repeat" },
+  { value: "recurring", label: "Recurring only" },
+  { value: "one_time", label: "One-time only" },
+];
+
+const RECURRENCE_OPTIONS = [
+  { value: "", label: "Does not repeat" },
+  { value: TASK_RECURRENCE.DAILY, label: "Daily" },
+  { value: TASK_RECURRENCE.WEEKLY, label: "Weekly" },
+  { value: TASK_RECURRENCE.MONTHLY, label: "Monthly" },
+  { value: TASK_RECURRENCE.YEARLY, label: "Yearly" },
+];
+
+const SECTION_LABELS = {
+  overdue: "Overdue",
+  today: "Today",
+  upcoming: "Upcoming",
+  completed: "Completed",
+};
+
+function memberLabel(member) {
+  if (!member) return "Unassigned";
+  const displayName =
+    member.displayName ||
+    member.display_name ||
+    member.preferredName ||
+    member.preferred_name ||
+    member.name ||
+    "";
+  return (
+    String(displayName || "").trim() ||
+    member.email ||
+    `User ${String(member.user_id || member.userId).slice(0, 8)}`
+  );
+}
+
+function initialsForMember(member) {
+  const label = memberLabel(member);
+  return label
+    .split("@")[0]
+    .split(/[.\s_-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("") || "?";
+}
+
+function formatDate(value) {
+  const date = parsePantryDate(value);
+  if (!date) return "No due date";
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function priorityClass(priority) {
+  if (priority === TASK_PRIORITY.HIGH) {
+    return "border-rose-200 bg-rose-50 text-rose-700";
+  }
+  if (priority === TASK_PRIORITY.LOW) {
+    return "border-gray-200 bg-gray-50 text-gray-600";
+  }
+  return "border-amber-200 bg-amber-50 text-amber-700";
+}
+
+function priorityAccentClass(priority) {
+  if (priority === TASK_PRIORITY.HIGH) return "bg-rose-400";
+  if (priority === TASK_PRIORITY.LOW) return "bg-gray-300";
+  return "bg-amber-400";
+}
+
+function priorityText(priority) {
+  if (priority === TASK_PRIORITY.HIGH) return "High";
+  if (priority === TASK_PRIORITY.LOW) return "Low";
+  return "Medium";
+}
+
+function dueDateClass(task) {
+  if (task.status === TASK_STATUS.COMPLETED) return "text-gray-500";
+  if (isTaskOverdue(task)) return "text-rose-700";
+  if (isTaskDueToday(task)) return "text-amber-700";
+  return "text-gray-500";
+}
+
+function taskFormFromTask(task = null) {
+  return {
+    title: task?.title ?? "",
+    description: task?.description ?? "",
+    assignedTo: task?.assignedTo ?? "",
+    locationId: task?.locationId ?? "",
+    dueDate: task?.dueDate ?? "",
+    priority: task?.priority ?? TASK_PRIORITY.MEDIUM,
+    recurrenceType: task?.recurrenceType ?? "",
+    recurrenceInterval: String(task?.recurrenceInterval ?? 1),
+  };
+}
+
+function upsertTask(tasks, task) {
+  if (!task?.id) return tasks;
+  const found = tasks.some((item) => item.id === task.id);
+  if (!found) return [task, ...tasks];
+  return tasks.map((item) => (item.id === task.id ? task : item));
+}
+
+function SummaryCard({ icon: Icon, label, value, detail }) {
+  return (
+    <div className="rounded-2xl border border-white/70 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-gray-500">{label}</p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight text-gray-950">
+            {value.toLocaleString()}
+          </p>
+          <p className="mt-1 text-xs leading-5 text-gray-500">{detail}</p>
+        </div>
+        <span className="grid h-11 w-11 shrink-0 place-items-center rounded-2xl border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] text-[var(--stocksense-brand)]">
+          <Icon className="h-4 w-4" />
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function TaskToast({ message, onDismiss }) {
+  useEffect(() => {
+    if (!message) return undefined;
+
+    const timeout = window.setTimeout(onDismiss, 3200);
+    return () => window.clearTimeout(timeout);
+  }, [message, onDismiss]);
+
+  if (!message) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed right-4 top-4 z-[90] w-[calc(100vw-2rem)] max-w-sm rounded-xl border border-emerald-200 bg-white px-4 py-3 text-sm font-semibold text-emerald-800 shadow-lg"
+    >
+      {message.text}
+    </div>
+  );
+}
+
+function TaskAvatar({ member }) {
+  const label = memberLabel(member);
+
+  return (
+    <span
+      className="grid h-8 w-8 shrink-0 place-items-center rounded-full border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] text-xs font-bold text-[var(--stocksense-brand)]"
+      title={label}
+    >
+      {initialsForMember(member)}
+    </span>
+  );
+}
+
+function TaskAssignee({ member }) {
+  const label = memberLabel(member);
+
+  return (
+    <span className="flex min-w-0 max-w-36 items-center gap-2 sm:max-w-40" title={label}>
+      <TaskAvatar member={member} />
+      <span className="min-w-0 truncate text-xs font-semibold text-gray-600">
+        {label}
+      </span>
+    </span>
+  );
+}
+
+function TaskRow({
+  task,
+  assignee,
+  completedBy,
+  location,
+  canEdit,
+  canDelete,
+  canToggle,
+  isPending,
+  onToggle,
+  onEdit,
+  onDelete,
+}) {
+  const completed = task.status === TASK_STATUS.COMPLETED;
+  const canOpenEditor = canEdit && !completed;
+  const DetailContainer = canOpenEditor ? "button" : "div";
+  const completedText =
+    completed && task.completedAt
+      ? `Completed ${formatDate(task.completedAt)}${
+          completedBy ? ` by ${memberLabel(completedBy)}` : ""
+        }`
+      : formatDate(task.dueDate);
+  const menuItems = [
+    canEdit && !completed ? { key: "edit", label: "Edit", onSelect: onEdit } : null,
+    canToggle
+      ? {
+          key: "toggle",
+          label: completed ? "Reopen" : "Mark complete",
+          onSelect: onToggle,
+        }
+      : null,
+    canDelete
+      ? {
+          key: "delete",
+          label: "Delete",
+          danger: true,
+          onSelect: onDelete,
+        }
+      : null,
+  ].filter(Boolean);
+  const hasActionsMenu = canEdit || canDelete;
+
+  return (
+    <article
+      className={cx(
+        "relative overflow-hidden rounded-2xl border bg-white p-3 shadow-sm transition hover:border-[var(--stocksense-brand-border)] hover:shadow-md sm:p-4",
+        hasActionsMenu ? "pr-12 sm:pr-14" : "pr-3 sm:pr-4",
+        completed ? "border-gray-100 opacity-85" : "border-gray-200/80"
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={`absolute inset-y-0 left-0 w-1 ${priorityAccentClass(task.priority)}`}
+      />
+      {hasActionsMenu ? (
+        <div className="absolute right-2.5 top-2.5 sm:right-3 sm:top-3">
+          <NativeDropdown
+            ariaLabel={`${task.title} actions`}
+            disabled={isPending}
+            items={menuItems}
+          />
+        </div>
+      ) : null}
+
+      <div className="grid min-w-0 gap-3 pl-2">
+        <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-start gap-3">
+          <button
+            type="button"
+            aria-label={`${completed ? "Reopen" : "Complete"} ${task.title}`}
+            aria-pressed={completed}
+            disabled={!canToggle || isPending}
+            onClick={onToggle}
+            className={`mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-full border transition ${
+              completed
+                ? "border-[var(--stocksense-brand)] bg-[var(--stocksense-brand)] text-white"
+                : "border-gray-300 bg-white text-transparent hover:border-[var(--stocksense-brand)]"
+            } disabled:cursor-not-allowed disabled:opacity-50`}
+          >
+            <LuCircleCheck className="h-4 w-4" />
+          </button>
+
+          <DetailContainer
+            {...(canOpenEditor ? { type: "button" } : {})}
+            onClick={canOpenEditor ? onEdit : undefined}
+            className="min-w-0 text-left"
+            aria-label={canOpenEditor ? `Edit ${task.title}` : undefined}
+          >
+            <div className="flex min-w-0 items-start gap-2">
+              <h3
+                className={`min-w-0 truncate text-sm font-semibold leading-6 text-gray-950 sm:text-base ${
+                  completed ? "text-gray-500 line-through decoration-gray-400" : ""
+                }`}
+                title={task.title}
+              >
+                {task.title}
+              </h3>
+              {task.isRecurring ? (
+                <span
+                  className="mt-1 inline-flex shrink-0 items-center rounded-full border border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] px-1.5 py-0.5 text-[var(--stocksense-brand)]"
+                  title="Repeating task"
+                >
+                  <LuRepeat2 className="h-3 w-3" />
+                </span>
+              ) : null}
+            </div>
+            {task.description ? (
+              <p className="mt-1 line-clamp-2 text-sm leading-5 text-gray-500">
+                {task.description}
+              </p>
+            ) : null}
+            <div className="mt-3 grid min-w-0 gap-1.5 text-xs sm:flex sm:flex-wrap sm:items-center sm:gap-x-3 sm:gap-y-1.5">
+              <span className="inline-flex min-w-0 items-center gap-1.5 text-gray-500">
+                <LuMapPin className="h-3.5 w-3.5 shrink-0 text-[var(--stocksense-brand)]" />
+                <span className="min-w-0 truncate">{location?.name ?? "No location"}</span>
+              </span>
+              <span className={`inline-flex min-w-0 items-center gap-1.5 font-medium ${dueDateClass(task)}`}>
+                <LuClock3 className="h-3.5 w-3.5 shrink-0" />
+                <span className="min-w-0 truncate">
+                  {completed ? completedText : `Due: ${completedText}`}
+                </span>
+              </span>
+            </div>
+          </DetailContainer>
+        </div>
+
+        <div className="flex min-w-0 items-center gap-3 border-t border-gray-100 pt-3">
+          <TaskAssignee member={assignee} />
+          <span aria-hidden="true" className="h-5 w-px shrink-0 bg-gray-200" />
+          <span
+            className={`inline-flex shrink-0 items-center gap-1.5 rounded-lg border px-2 py-1 text-xs font-semibold ${priorityClass(
+              task.priority
+            )}`}
+          >
+            <LuFlag className="h-3.5 w-3.5" />
+            {priorityText(task.priority)}
+          </span>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function TaskEditorModal({
+  isOpen,
+  mode,
+  form,
+  setForm,
+  members,
+  locations,
+  isSaving,
+  error,
+  onClose,
+  onSave,
+}) {
+  const memberOptions = [
+    { value: "", label: "Unassigned" },
+    ...members.map((member) => ({
+      value: member.user_id,
+      label: memberLabel(member),
+      startContent: <TaskAvatar member={member} />,
+    })),
+  ];
+  const locationOptions = [
+    { value: "", label: "No location" },
+    ...locations.map((location) => ({ value: location.id, label: location.name })),
+  ];
+  const repeats = Boolean(form.recurrenceType);
+
+  const setValue = (key, value) => {
+    setForm((current) => ({ ...current, [key]: value }));
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => !open && onClose()}
+      size="2xl"
+      classNames={{
+        wrapper: "max-md:items-end",
+        base: "max-md:m-0 max-md:w-screen max-md:max-w-none max-md:rounded-b-none max-md:rounded-t-2xl",
+      }}
+    >
+      <ModalContent className="wherekeep-modal-content w-full rounded-2xl bg-white shadow-2xl max-md:max-h-[88svh] max-md:overflow-hidden max-md:rounded-b-none max-md:rounded-t-2xl">
+        <ModalHeader className="border-b border-gray-100">
+          <h2 className="text-lg font-semibold text-gray-950">
+            {mode === "edit" ? "Edit task" : "New task"}
+          </h2>
+        </ModalHeader>
+        <ModalBody className="grid gap-4 overflow-y-auto pt-5 max-md:max-h-[calc(88svh-9rem)]">
+          <NativeInput
+            label="Task name"
+            value={form.title}
+            onValueChange={(value) => setValue("title", value)}
+            disabled={isSaving}
+          />
+          <label className="space-y-1">
+            <span className="block text-xs font-semibold text-gray-700">
+              Description
+            </span>
+            <textarea
+              value={form.description}
+              onChange={(event) => setValue("description", event.target.value)}
+              disabled={isSaving}
+              rows={3}
+              className="w-full resize-none rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-900 shadow-sm outline-none transition focus:border-[var(--stocksense-brand)] focus:ring-1 focus:ring-[var(--stocksense-brand-border)] disabled:bg-gray-50"
+            />
+          </label>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <NativeSelect
+              aria-label="Assign task"
+              label="Assign to"
+              value={form.assignedTo}
+              onChange={(value) => setValue("assignedTo", value)}
+              options={memberOptions}
+              disabled={isSaving}
+            />
+            <NativeSelect
+              aria-label="Task location"
+              label="Location"
+              value={form.locationId}
+              onChange={(value) => setValue("locationId", value)}
+              options={locationOptions}
+              disabled={isSaving}
+            />
+            <NativeDatePicker
+              label="Due date"
+              value={form.dueDate}
+              onChange={(value) => setValue("dueDate", value?.toString?.() ?? "")}
+              disabled={isSaving}
+            />
+            <NativeSelect
+              aria-label="Task priority"
+              label="Priority"
+              value={form.priority}
+              onChange={(value) => setValue("priority", value)}
+              options={PRIORITY_OPTIONS}
+              disabled={isSaving}
+            />
+            <NativeSelect
+              aria-label="Repeat task"
+              label="Repeat"
+              value={form.recurrenceType}
+              onChange={(value) => setValue("recurrenceType", value)}
+              options={RECURRENCE_OPTIONS}
+              disabled={isSaving}
+            />
+            {repeats ? (
+              <NativeInput
+                label="Every"
+                type="number"
+                min="1"
+                value={form.recurrenceInterval}
+                onValueChange={(value) => setValue("recurrenceInterval", value)}
+                disabled={isSaving}
+              />
+            ) : null}
+          </div>
+          {error ? (
+            <p
+              role="alert"
+              className="w-fit max-w-full rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700"
+            >
+              {error}
+            </p>
+          ) : null}
+        </ModalBody>
+        <ModalFooter className="flex justify-end gap-2 border-t border-gray-100 max-md:flex-col-reverse max-md:pb-[max(1rem,env(safe-area-inset-bottom))]">
+          <NativeButton variant="light" onPress={onClose} isDisabled={isSaving}>
+            Cancel
+          </NativeButton>
+          <NativeButton
+            className="bg-[var(--stocksense-brand)] text-white"
+            onPress={onSave}
+            isLoading={isSaving}
+            isDisabled={!form.title.trim()}
+          >
+            {mode === "edit" ? "Save changes" : "Create task"}
+          </NativeButton>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default function TasksPageClient({
+  initialTasks = [],
+  initialError = null,
+  members = [],
+  locations = [],
+  currentUserId = null,
+  currentUserRole = "viewer",
+}) {
+  const [tasks, setTasks] = useState(initialTasks);
+  const [activeTab, setActiveTab] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [assigneeFilter, setAssigneeFilter] = useState("all");
+  const [priorityFilter, setPriorityFilter] = useState("all");
+  const [locationFilter, setLocationFilter] = useState("all");
+  const [dueDateFilter, setDueDateFilter] = useState("all");
+  const [recurringFilter, setRecurringFilter] = useState("all");
+  const [sortBy, setSortBy] = useState(TASK_SORT.DUE_DATE);
+  const [showFilters, setShowFilters] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(initialError);
+  const [toastMessage, setToastMessage] = useState(null);
+  const [pendingTaskId, setPendingTaskId] = useState(null);
+  const [editor, setEditor] = useState({
+    open: false,
+    mode: "create",
+    task: null,
+  });
+  const [form, setForm] = useState(taskFormFromTask());
+  const [formError, setFormError] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteCandidate, setDeleteCandidate] = useState(null);
+
+  const memberById = useMemo(
+    () => new Map(members.map((member) => [String(member.user_id), member])),
+    [members]
+  );
+  const locationById = useMemo(
+    () => new Map(locations.map((location) => [String(location.id), location])),
+    [locations]
+  );
+  const currentMemberRecord = memberById.get(String(currentUserId));
+  const currentMember = {
+    ...(currentMemberRecord ?? {}),
+    role: currentMemberRecord?.role ?? currentUserRole,
+    household_id:
+      currentMemberRecord?.household_id ??
+      currentMemberRecord?.householdId ??
+      "current",
+  };
+  const canCreate = canCreateTask(currentMember);
+  const assigneeOptions = [
+    { value: "all", label: "Any assignee" },
+    { value: "unassigned", label: "Unassigned" },
+    ...members.map((member) => ({
+      value: member.user_id,
+      label: memberLabel(member),
+    })),
+  ];
+  const locationOptions = [
+    { value: "all", label: "Any location" },
+    { value: "none", label: "No location" },
+    ...locations.map((location) => ({ value: location.id, label: location.name })),
+  ];
+  const activeFilterCount = [
+    statusFilter !== "all",
+    assigneeFilter !== "all",
+    priorityFilter !== "all",
+    locationFilter !== "all",
+    dueDateFilter !== "all",
+    recurringFilter !== "all",
+  ].filter(Boolean).length;
+
+  const filteredTasks = useMemo(() => {
+    return tasks.filter((task) => {
+      const assignedTo = task.assignedTo ? String(task.assignedTo) : "";
+      const createdBy = task.createdBy ? String(task.createdBy) : "";
+      const locationId = task.locationId ? String(task.locationId) : "";
+      const currentUserKey = currentUserId ? String(currentUserId) : "";
+
+      if (activeTab === "assigned" && assignedTo !== currentUserKey) return false;
+      if (activeTab === "created" && createdBy !== currentUserKey) return false;
+      if (activeTab === "unassigned" && task.assignedTo) return false;
+      if (activeTab === "due_today" && !isTaskDueToday(task)) return false;
+      if (activeTab === "completed" && task.status !== TASK_STATUS.COMPLETED) return false;
+      if (statusFilter !== "all" && task.status !== statusFilter) return false;
+      if (priorityFilter !== "all" && task.priority !== priorityFilter) return false;
+      if (locationFilter === "none" && task.locationId) return false;
+      if (
+        locationFilter !== "all" &&
+        locationFilter !== "none" &&
+        locationId !== String(locationFilter)
+      ) {
+        return false;
+      }
+      if (dueDateFilter === "overdue" && !isTaskOverdue(task)) return false;
+      if (dueDateFilter === "today" && !isTaskDueToday(task)) return false;
+      if (dueDateFilter === "upcoming" && !isTaskUpcoming(task)) return false;
+      if (dueDateFilter === "none" && task.dueDate) return false;
+      if (recurringFilter === "recurring" && !task.isRecurring) return false;
+      if (recurringFilter === "one_time" && task.isRecurring) return false;
+      if (assigneeFilter === "unassigned" && task.assignedTo) return false;
+      if (
+        assigneeFilter !== "all" &&
+        assigneeFilter !== "unassigned" &&
+        assignedTo !== String(assigneeFilter)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [
+    activeTab,
+    assigneeFilter,
+    currentUserId,
+    dueDateFilter,
+    locationFilter,
+    priorityFilter,
+    recurringFilter,
+    statusFilter,
+    tasks,
+  ]);
+  const summary = useMemo(() => summarizeTasks(tasks), [tasks]);
+  const groupedTasks = useMemo(
+    () => groupTasksByDate(sortTasks(filteredTasks, sortBy)),
+    [filteredTasks, sortBy]
+  );
+
+  function showSuccessToast(text) {
+    setErrorMessage(null);
+    setToastMessage({ id: Date.now(), text });
+  }
+
+  function openCreate() {
+    setForm(taskFormFromTask());
+    setFormError(null);
+    setEditor({ open: true, mode: "create", task: null });
+  }
+
+  function openEdit(task) {
+    setForm(taskFormFromTask(task));
+    setFormError(null);
+    setEditor({ open: true, mode: "edit", task });
+  }
+
+  function closeEditor() {
+    if (isSaving) return;
+    setEditor({ open: false, mode: "create", task: null });
+    setFormError(null);
+  }
+
+  async function saveTask() {
+    if (isSaving) return;
+
+    setIsSaving(true);
+    setFormError(null);
+
+    const payload = {
+      ...form,
+      isRecurring: Boolean(form.recurrenceType),
+      recurrenceInterval: form.recurrenceInterval || 1,
+    };
+    const result =
+      editor.mode === "edit"
+        ? await updateTaskAction(editor.task.id, payload)
+        : await createTaskAction(payload);
+
+    setIsSaving(false);
+
+    if (result.error) {
+      setFormError(result.error);
+      return;
+    }
+
+    setTasks((current) => upsertTask(current, result.data));
+    emitInventoryChange({
+      entity: "task",
+      action: editor.mode === "edit" ? "updated" : "added",
+      task: result.data,
+    });
+    showSuccessToast(editor.mode === "edit" ? "Task updated." : "Task created.");
+    closeEditor();
+  }
+
+  async function toggleTask(task) {
+    if (pendingTaskId) return;
+    setPendingTaskId(task.id);
+    setErrorMessage(null);
+
+    const result =
+      task.status === TASK_STATUS.COMPLETED
+        ? await reopenTaskAction(task.id)
+        : await completeTaskAction(task.id);
+
+    setPendingTaskId(null);
+
+    if (result.error) {
+      setErrorMessage(result.error);
+      return;
+    }
+
+    const updatedTask = result.data?.task ?? result.data;
+    setTasks((current) => {
+      let next = upsertTask(current, updatedTask);
+      if (result.data?.nextTask) next = upsertTask(next, result.data.nextTask);
+      return next;
+    });
+    emitInventoryChange({
+      entity: "task",
+      action: updatedTask.status === TASK_STATUS.COMPLETED ? "completed" : "reopened",
+      task: updatedTask,
+      nextTask: result.data?.nextTask ?? null,
+    });
+    showSuccessToast(
+      updatedTask.status === TASK_STATUS.COMPLETED
+        ? "Task completed."
+        : "Task reopened."
+    );
+  }
+
+  async function deleteTask(task) {
+    setPendingTaskId(task.id);
+    setErrorMessage(null);
+    const result = await deleteTaskAction(task.id);
+    setPendingTaskId(null);
+
+    if (result.error) {
+      setErrorMessage(result.error);
+      return;
+    }
+
+    setTasks((current) => current.filter((item) => item.id !== task.id));
+    setDeleteCandidate(null);
+    emitInventoryChange({ entity: "task", action: "deleted", task });
+    showSuccessToast("Task deleted.");
+  }
+
+  const hasTasks = filteredTasks.length > 0;
+
+  return (
+    <div className="space-y-4 text-gray-700 sm:space-y-5">
+      <header className="flex items-center justify-between gap-3 sm:flex-wrap sm:items-start sm:gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-gray-950 sm:text-3xl">
+            Tasks
+          </h1>
+          <p className="mt-2 hidden max-w-2xl text-sm leading-6 text-gray-600 sm:block">
+            Keep your home running smoothly. Assign chores and stay on top of what matters.
+          </p>
+        </div>
+        {canCreate ? (
+          <NativeButton
+            onPress={openCreate}
+            aria-label="New task"
+            className="max-sm:h-10 max-sm:w-10 max-sm:min-w-10 max-sm:rounded-full max-sm:p-0"
+            startContent={
+              <>
+                <LuPlus className="h-4 w-4 sm:hidden" />
+                <LuClipboardCheck className="hidden h-4 w-4 sm:block" />
+              </>
+            }
+          >
+            <span className="max-sm:sr-only">New Task</span>
+          </NativeButton>
+        ) : null}
+      </header>
+
+      <section className="hidden gap-4 sm:grid md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          icon={LuClipboardCheck}
+          label="All Tasks"
+          value={summary.active}
+          detail="Active household tasks"
+        />
+        <SummaryCard
+          icon={LuClock3}
+          label="Due Today"
+          value={summary.dueToday}
+          detail="Open tasks due today"
+        />
+        <SummaryCard
+          icon={LuCalendarClock}
+          label="Upcoming"
+          value={summary.upcoming}
+          detail="Due in the next 7 days"
+        />
+        <SummaryCard
+          icon={LuCircleCheck}
+          label="Completed"
+          value={summary.completedThisMonth}
+          detail="Finished this month"
+        />
+      </section>
+
+      <section className="rounded-2xl border border-white/70 bg-white p-3 shadow-sm sm:p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 pb-1">
+            <NativeSelect
+              aria-label="Task view"
+              className="sm:hidden"
+              value={activeTab}
+              onChange={setActiveTab}
+              options={MOBILE_TAB_OPTIONS}
+            />
+            <div className="hidden min-w-0 flex-wrap gap-2 sm:flex">
+              {TABS.filter((tab) => !tab.mobileOnly).map((tab) => (
+                <button
+                  key={tab.value}
+                  type="button"
+                  onClick={() => setActiveTab(tab.value)}
+                  className={cx(
+                    "inline-flex min-h-10 shrink-0 items-center justify-center rounded-xl px-3 text-center text-sm font-semibold transition",
+                    activeTab === tab.value
+                      ? "bg-[var(--stocksense-brand)] text-white"
+                      : "border border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+                  )}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowFilters((current) => !current)}
+            aria-expanded={showFilters}
+            aria-controls="task-filters-panel"
+            className={cx(
+              "inline-flex min-h-10 shrink-0 items-center justify-center gap-2 rounded-xl border px-3 text-sm font-semibold transition",
+              showFilters || activeFilterCount > 0
+                ? "border-[var(--stocksense-brand-border)] bg-[var(--stocksense-brand-soft)] text-[var(--stocksense-brand)]"
+                : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+            )}
+          >
+            <LuFilter className="h-4 w-4" />
+            <span>Filter</span>
+            {activeFilterCount > 0 ? (
+              <span className="grid min-h-5 min-w-5 place-items-center rounded-full bg-[var(--stocksense-brand)] px-1 text-[10px] font-bold leading-none text-white">
+                {activeFilterCount}
+              </span>
+            ) : null}
+          </button>
+        </div>
+
+        {showFilters ? (
+          <div
+            id="task-filters-panel"
+            className="mt-3 rounded-2xl border border-gray-100 bg-gray-50/70 p-3"
+          >
+            <div className="grid w-full grid-cols-2 gap-2 md:grid-cols-3 xl:grid-cols-7">
+              <NativeSelect
+                aria-label="Filter by assignee"
+                value={assigneeFilter}
+                onChange={setAssigneeFilter}
+                options={assigneeOptions}
+              />
+              <NativeSelect
+                aria-label="Filter by status"
+                value={statusFilter}
+                onChange={setStatusFilter}
+                options={STATUS_OPTIONS}
+              />
+              <NativeSelect
+                aria-label="Filter by priority"
+                value={priorityFilter}
+                onChange={setPriorityFilter}
+                options={[{ value: "all", label: "Any priority" }, ...PRIORITY_OPTIONS]}
+              />
+              <NativeSelect
+                aria-label="Filter by location"
+                value={locationFilter}
+                onChange={setLocationFilter}
+                options={locationOptions}
+              />
+              <NativeSelect
+                aria-label="Filter by due date"
+                value={dueDateFilter}
+                onChange={setDueDateFilter}
+                options={DUE_DATE_FILTER_OPTIONS}
+              />
+              <NativeSelect
+                aria-label="Filter by recurring tasks"
+                value={recurringFilter}
+                onChange={setRecurringFilter}
+                options={RECURRING_FILTER_OPTIONS}
+              />
+              <NativeSelect
+                aria-label="Sort tasks"
+                value={sortBy}
+                onChange={setSortBy}
+                options={SORT_OPTIONS}
+              />
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      {errorMessage ? (
+        <p
+          role="alert"
+          className="w-fit max-w-full rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700"
+        >
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <section className="space-y-5">
+        {Object.entries(groupedTasks).map(([section, sectionTasks]) =>
+          sectionTasks.length ? (
+            <div key={section} className="space-y-3">
+              <h2 className="text-sm font-bold uppercase tracking-[0.16em] text-gray-400">
+                {SECTION_LABELS[section]}
+              </h2>
+              <div className="grid gap-3">
+                {sectionTasks.map((task) => {
+                  const assignee = task.assignedTo
+                    ? memberById.get(String(task.assignedTo))
+                    : null;
+                  const completedBy = task.completedBy
+                    ? memberById.get(String(task.completedBy))
+                    : null;
+                  const location = task.locationId
+                    ? locationById.get(String(task.locationId))
+                    : null;
+                  return (
+                    <TaskRow
+                      key={task.id}
+                      task={task}
+                      assignee={assignee}
+                      completedBy={completedBy}
+                      location={location}
+                      canEdit={canEditTask(currentMember)}
+                      canDelete={canDeleteTask(currentMember)}
+                      canToggle={canCompleteTask(currentMember, currentUserId, {
+                        assigned_to: task.assignedTo,
+                      })}
+                      isPending={pendingTaskId === task.id}
+                      onToggle={() => toggleTask(task)}
+                      onEdit={() => openEdit(task)}
+                      onDelete={() => setDeleteCandidate(task)}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          ) : null
+        )}
+
+        {!hasTasks ? (
+          <div className="rounded-2xl border border-dashed border-[var(--stocksense-brand-border)] bg-white px-6 py-12 text-center shadow-sm">
+            <div className="mx-auto grid h-14 w-14 place-items-center rounded-2xl bg-[var(--stocksense-brand-soft)] text-[var(--stocksense-brand)]">
+              {activeTab === "assigned" ? (
+                <LuCircleUser className="h-6 w-6" />
+              ) : (
+                <LuClipboardCheck className="h-6 w-6" />
+              )}
+            </div>
+            <h2 className="mt-4 text-lg font-semibold text-gray-950">
+              {activeTab === "assigned" ? "Nothing assigned to you" : "No tasks yet"}
+            </h2>
+            <p className="mx-auto mt-1 max-w-md text-sm leading-6 text-gray-500">
+              {activeTab === "assigned"
+                ? "You're all caught up."
+                : "Create a household task or chore to keep everyone on track."}
+            </p>
+            {canCreate && activeTab !== "assigned" ? (
+              <NativeButton className="mt-5" onPress={openCreate}>
+                Create Task
+              </NativeButton>
+            ) : null}
+          </div>
+        ) : null}
+      </section>
+
+      <TaskEditorModal
+        isOpen={editor.open}
+        mode={editor.mode}
+        form={form}
+        setForm={setForm}
+        members={members}
+        locations={locations}
+        isSaving={isSaving}
+        error={formError}
+        onClose={closeEditor}
+        onSave={saveTask}
+      />
+      <ConfirmDeleteModal
+        isOpen={Boolean(deleteCandidate)}
+        title="Delete task"
+        description={
+          deleteCandidate
+            ? `Delete "${deleteCandidate.title}"? This cannot be undone.`
+            : ""
+        }
+        confirmLabel="Delete task"
+        isDeleting={Boolean(deleteCandidate && pendingTaskId === deleteCandidate.id)}
+        onCancel={() => {
+          if (!pendingTaskId) setDeleteCandidate(null);
+        }}
+        onConfirm={() => {
+          if (deleteCandidate) void deleteTask(deleteCandidate);
+        }}
+      />
+      <TaskToast
+        message={toastMessage}
+        onDismiss={() => setToastMessage(null)}
+      />
+    </div>
+  );
+}

--- a/components/ui/NativeDropdown.jsx
+++ b/components/ui/NativeDropdown.jsx
@@ -1,23 +1,54 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { FaEllipsisV } from "react-icons/fa";
 import { cx } from "@/components/ui/classNames";
 import useTransitionMount from "@/components/ui/useTransitionMount";
+
+function getDropdownPosition(rect, itemCount) {
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+  const margin = 12;
+  const gap = 8;
+  const estimatedHeight = Math.min(Math.max(itemCount * 36 + 8, 44), 288);
+  const spaceBelow = Math.max(0, viewportHeight - rect.bottom - margin - gap);
+  const spaceAbove = Math.max(0, rect.top - margin - gap);
+  const placement =
+    spaceBelow < estimatedHeight && spaceAbove > spaceBelow ? "top" : "bottom";
+  const maxHeight = Math.max(
+    44,
+    Math.min(288, placement === "top" ? spaceAbove : spaceBelow)
+  );
+  const top =
+    placement === "top"
+      ? Math.max(margin, rect.top - Math.min(estimatedHeight, maxHeight) - gap)
+      : Math.min(
+          rect.bottom + gap,
+          Math.max(margin, viewportHeight - margin - maxHeight)
+        );
+
+  return {
+    top,
+    right: Math.max(margin, viewportWidth - rect.right),
+    maxHeight,
+    placement,
+  };
+}
 
 export default function NativeDropdown({
   ariaLabel,
   buttonClassName = "h-9 w-9 min-w-9",
   className = "",
   disabled = false,
-  items,
+  items = [],
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [menuPosition, setMenuPosition] = useState(null);
   const buttonRef = useRef(null);
   const menuRef = useRef(null);
   const { isVisible, shouldRender } = useTransitionMount(isOpen);
+  const visibleItems = useMemo(() => items.filter(Boolean), [items]);
 
   useEffect(() => {
     if (!isOpen) return undefined;
@@ -50,10 +81,7 @@ export default function NativeDropdown({
 
     const rect = buttonRef.current?.getBoundingClientRect();
     if (rect) {
-      setMenuPosition({
-        top: rect.bottom + 8,
-        right: Math.max(12, window.innerWidth - rect.right),
-      });
+      setMenuPosition(getDropdownPosition(rect, visibleItems.length));
     }
     setIsOpen((current) => !current);
   };
@@ -68,15 +96,20 @@ export default function NativeDropdown({
             style={{
               top: `${menuPosition.top}px`,
               right: `${menuPosition.right}px`,
+              maxHeight: `${menuPosition.maxHeight}px`,
             }}
             className={cx(
-              "fixed z-[180] origin-top-right min-w-48 overflow-hidden rounded-xl border border-gray-200 bg-white py-1 text-sm shadow-xl transition duration-200 ease-out motion-reduce:transition-none",
+              "fixed z-[180] min-w-48 overflow-y-auto rounded-xl border border-gray-200 bg-white py-1 text-sm shadow-xl transition duration-200 ease-out motion-reduce:transition-none",
+              menuPosition.placement === "top" ? "origin-bottom-right" : "origin-top-right",
               isVisible
                 ? "translate-y-0 scale-100 opacity-100"
-                : "pointer-events-none -translate-y-2 scale-95 opacity-0"
+                : cx(
+                    "pointer-events-none scale-95 opacity-0",
+                    menuPosition.placement === "top" ? "translate-y-2" : "-translate-y-2"
+                  )
             )}
           >
-            {items.filter(Boolean).map((item) => (
+            {visibleItems.map((item) => (
               <button
                 key={item.key}
                 type="button"

--- a/components/ui/NativeSelect.jsx
+++ b/components/ui/NativeSelect.jsx
@@ -117,7 +117,9 @@ export default function NativeSelect({
                   {option.startContent ? (
                     <span className="shrink-0">{option.startContent}</span>
                   ) : null}
-                  <span className="min-w-0 flex-1">{option.label}</span>
+                  <span className="min-w-0 flex-1 truncate" title={option.label}>
+                    {option.label}
+                  </span>
                 </button>
               );
             })}

--- a/tests/component/dashboard/RecentActivity.test.jsx
+++ b/tests/component/dashboard/RecentActivity.test.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const activityActionMocks = vi.hoisted(() => ({
+  getRecentActivityAction: vi.fn(),
+}));
+
+vi.mock("@/app/actions/activity", () => activityActionMocks);
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }) => (
+    <a href={typeof href === "string" ? href : href?.pathname ?? ""} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const { default: RecentActivity } = await import(
+  "@/components/dashboard/RecentActivity"
+);
+
+describe("RecentActivity", () => {
+  beforeEach(() => {
+    activityActionMocks.getRecentActivityAction.mockReset();
+    activityActionMocks.getRecentActivityAction.mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: "activity_task_1",
+            entity_type: "task",
+            entity_id: "task_1",
+            action: "completed",
+            item_name: "Take out trash",
+            created_at: "2026-01-05T00:00:00.000Z",
+            changes: {},
+          },
+        ],
+        nextCursor: null,
+        hasMore: false,
+      },
+      error: null,
+    });
+  });
+
+  it("filters full recent activity by activity type", async () => {
+    const { user } = renderWithProviders(
+      <RecentActivity
+        variant="full"
+        items={[]}
+        members={[]}
+        effectivePlanId="free"
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /filter recent activity by type/i })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /filter recent activity by type/i })
+    );
+    await user.click(await screen.findByRole("option", { name: /tasks/i }));
+
+    await waitFor(() => {
+      expect(activityActionMocks.getRecentActivityAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: "task",
+          action: "all",
+        })
+      );
+    });
+    expect(await screen.findByText("Take out trash")).toBeInTheDocument();
+  });
+});

--- a/tests/component/tasks/TasksPageClient.test.jsx
+++ b/tests/component/tasks/TasksPageClient.test.jsx
@@ -1,0 +1,278 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers/render";
+import { createTestMember } from "@/tests/helpers/factories";
+
+const actionMocks = vi.hoisted(() => ({
+  completeTaskAction: vi.fn(),
+  createTaskAction: vi.fn(),
+  deleteTaskAction: vi.fn(),
+  reopenTaskAction: vi.fn(),
+  updateTaskAction: vi.fn(),
+}));
+
+vi.mock("@/app/actions/tasks", () => actionMocks);
+
+const { default: TasksPageClient } = await import(
+  "@/components/tasks/TasksPageClient"
+);
+
+function createClientTask(overrides = {}) {
+  return {
+    id: "task_1",
+    householdId: "household_1",
+    title: "Take out trash",
+    description: null,
+    assignedTo: "user_owner",
+    createdBy: "user_owner",
+    locationId: "location_1",
+    status: "todo",
+    priority: "medium",
+    dueDate: "2026-08-18",
+    isRecurring: false,
+    recurrenceType: null,
+    recurrenceInterval: 1,
+    recurringParentTaskId: null,
+    completedAt: null,
+    completedBy: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const ownerMember = createTestMember();
+const viewerMember = createTestMember({
+  user_id: "user_viewer",
+  email: "viewer@example.test",
+  role: "viewer",
+  displayName: "Viewer Name",
+});
+const locations = [{ id: "location_1", name: "Kitchen" }];
+
+describe("TasksPageClient", () => {
+  beforeEach(() => {
+    actionMocks.completeTaskAction.mockReset();
+    actionMocks.createTaskAction.mockReset();
+    actionMocks.deleteTaskAction.mockReset();
+    actionMocks.reopenTaskAction.mockReset();
+    actionMocks.updateTaskAction.mockReset();
+  });
+
+  it("groups household tasks by due date sections", () => {
+    vi.useFakeTimers({ now: new Date("2026-08-18T12:00:00.000Z") });
+    try {
+      renderWithProviders(
+        <TasksPageClient
+          initialTasks={[
+            createClientTask({
+              id: "overdue",
+              title: "Replace filter",
+              dueDate: "2026-08-17",
+              priority: "high",
+            }),
+            createClientTask({
+              id: "today",
+              title: "Water plants",
+              dueDate: "2026-08-18",
+            }),
+            createClientTask({
+              id: "completed",
+            title: "Clean counters",
+            status: "completed",
+            completedAt: "2026-08-18T08:00:00.000Z",
+            completedBy: "user_viewer",
+          }),
+        ]}
+        members={[ownerMember, viewerMember]}
+          locations={locations}
+          currentUserId="user_owner"
+          currentUserRole="owner"
+        />
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(screen.getByRole("heading", { name: "Overdue" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Completed" })).toBeInTheDocument();
+    expect(screen.getByText("Replace filter")).toBeInTheDocument();
+    expect(screen.getByText("Water plants")).toBeInTheDocument();
+    expect(screen.getByText("Clean counters")).toBeInTheDocument();
+    expect(screen.getByText(/completed aug 18 by viewer name/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit clean counters/i })).not.toBeInTheDocument();
+  });
+
+  it("does not show edit in the actions menu for completed tasks", async () => {
+    const { user } = renderWithProviders(
+      <TasksPageClient
+        initialTasks={[
+          createClientTask({
+            id: "completed",
+            title: "Clean counters",
+            status: "completed",
+            completedAt: "2026-08-18T08:00:00.000Z",
+            completedBy: "user_owner",
+          }),
+        ]}
+        members={[ownerMember]}
+        locations={locations}
+        currentUserId="user_owner"
+        currentUserRole="owner"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /clean counters actions/i }));
+
+    expect(screen.queryByRole("menuitem", { name: /^edit$/i })).not.toBeInTheDocument();
+    expect(await screen.findByRole("menuitem", { name: /reopen/i })).toBeInTheDocument();
+  });
+
+  it("filters tasks from the compact task view dropdown", async () => {
+    const { user } = renderWithProviders(
+      <TasksPageClient
+        initialTasks={[
+          createClientTask({
+            id: "mine",
+            title: "Wash dishes",
+            assignedTo: "user_owner",
+          }),
+          createClientTask({
+            id: "other",
+            title: "Sweep garage",
+            assignedTo: "user_viewer",
+          }),
+        ]}
+        members={[ownerMember, viewerMember]}
+        locations={locations}
+        currentUserId="user_owner"
+        currentUserRole="owner"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /task view/i }));
+    await user.click(await screen.findByRole("option", { name: /mine/i }));
+
+    expect(screen.getByText("Wash dishes")).toBeInTheDocument();
+    expect(screen.queryByText("Sweep garage")).not.toBeInTheDocument();
+  });
+
+  it("lets household editors create tasks from the modal", async () => {
+    const createdTask = createClientTask({
+      id: "task_new",
+      title: "Water herbs",
+      assignedTo: null,
+      locationId: null,
+    });
+    actionMocks.createTaskAction.mockResolvedValue({ data: createdTask, error: null });
+
+    const { user } = renderWithProviders(
+      <TasksPageClient
+        initialTasks={[]}
+        members={[ownerMember]}
+        locations={locations}
+        currentUserId="user_owner"
+        currentUserRole="owner"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /new task/i }));
+    const dialog = await screen.findByRole("dialog");
+    await user.type(within(dialog).getByLabelText(/task name/i), "Water herbs");
+    await user.click(within(dialog).getByRole("button", { name: /create task/i }));
+
+    await waitFor(() => {
+      expect(actionMocks.createTaskAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Water herbs",
+          priority: "medium",
+          isRecurring: false,
+        })
+      );
+    });
+    expect(await screen.findByText("Task created.")).toBeInTheDocument();
+    expect(screen.getByText("Water herbs")).toBeInTheDocument();
+  });
+
+  it("allows viewers to complete only their assigned tasks", async () => {
+    const assignedTask = createClientTask({
+      id: "viewer_task",
+      title: "Wash dishes",
+      assignedTo: "user_viewer",
+    });
+    actionMocks.completeTaskAction.mockResolvedValue({
+      data: {
+        task: {
+          ...assignedTask,
+          status: "completed",
+          completedAt: "2026-08-18T12:30:00.000Z",
+          completedBy: "user_viewer",
+        },
+        nextTask: null,
+      },
+      error: null,
+    });
+
+    const { user } = renderWithProviders(
+      <TasksPageClient
+        initialTasks={[
+          assignedTask,
+          createClientTask({
+            id: "other_task",
+            title: "Sweep garage",
+            assignedTo: "user_owner",
+          }),
+          createClientTask({
+            id: "unassigned_task",
+            title: "Take recycling",
+            assignedTo: null,
+          }),
+        ]}
+        members={[ownerMember, viewerMember]}
+        locations={locations}
+        currentUserId="user_viewer"
+        currentUserRole="viewer"
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /new task/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /complete sweep garage/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /complete take recycling/i })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: /wash dishes actions/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /take recycling actions/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /complete wash dishes/i }));
+
+    await waitFor(() => {
+      expect(actionMocks.completeTaskAction).toHaveBeenCalledWith("viewer_task");
+    });
+    expect(await screen.findByText("Task completed.")).toBeInTheDocument();
+  });
+
+  it("shows delete success feedback as a toast", async () => {
+    actionMocks.deleteTaskAction.mockResolvedValue({ data: { id: "task_1" }, error: null });
+
+    const { user } = renderWithProviders(
+      <TasksPageClient
+        initialTasks={[createClientTask()]}
+        members={[ownerMember]}
+        locations={locations}
+        currentUserId="user_owner"
+        currentUserRole="owner"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /take out trash actions/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /delete/i }));
+    await user.click(await screen.findByRole("button", { name: /delete task/i }));
+
+    await waitFor(() => {
+      expect(actionMocks.deleteTaskAction).toHaveBeenCalledWith("task_1");
+    });
+    expect(within(await screen.findByRole("status")).getByText("Task deleted.")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.queryByText("Take out trash")).not.toBeInTheDocument();
+  });
+});

--- a/tests/component/ui/NativeDropdown.test.jsx
+++ b/tests/component/ui/NativeDropdown.test.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const { default: NativeDropdown } = await import(
+  "@/components/ui/NativeDropdown"
+);
+
+describe("NativeDropdown", () => {
+  it("opens upward when the trigger is near the bottom of the viewport", async () => {
+    const originalInnerHeight = window.innerHeight;
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 800,
+    });
+
+    try {
+      const { user } = renderWithProviders(
+        <NativeDropdown
+          ariaLabel="Task actions"
+          items={[
+            { key: "edit", label: "Edit", onSelect: () => {} },
+            { key: "delete", label: "Delete", onSelect: () => {} },
+          ]}
+        />
+      );
+      const trigger = screen.getByRole("button", { name: /task actions/i });
+      trigger.getBoundingClientRect = () => ({
+        x: 744,
+        y: 584,
+        top: 584,
+        bottom: 620,
+        left: 744,
+        right: 780,
+        width: 36,
+        height: 36,
+        toJSON: () => {},
+      });
+
+      await user.click(trigger);
+
+      const menu = await screen.findByRole("menu", { name: /task actions/i });
+      expect(Number.parseFloat(menu.style.top)).toBeLessThan(584);
+      expect(Number.parseFloat(menu.style.maxHeight)).toBeLessThanOrEqual(288);
+    } finally {
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        value: originalInnerHeight,
+      });
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+});

--- a/tests/helpers/factories.js
+++ b/tests/helpers/factories.js
@@ -95,6 +95,30 @@ export function createTestShoppingListEntry(overrides = {}) {
   };
 }
 
+export function createTestTask(overrides = {}) {
+  return {
+    id: "task_1",
+    household_id: "household_1",
+    title: "Take out trash",
+    description: null,
+    assigned_to: "user_owner",
+    created_by: "user_owner",
+    location_id: "location_1",
+    status: "todo",
+    priority: "medium",
+    due_date: "2026-08-17",
+    is_recurring: false,
+    recurrence_type: null,
+    recurrence_interval: 1,
+    recurring_parent_task_id: null,
+    completed_at: null,
+    completed_by: null,
+    created_at: "2026-08-01T00:00:00.000Z",
+    updated_at: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
 export function createRoleFixtures() {
   return {
     owner: createTestMember({ role: HOUSEHOLD_ROLES.OWNER }),

--- a/tests/integration/activityActions.test.js
+++ b/tests/integration/activityActions.test.js
@@ -160,6 +160,7 @@ describe("activity server actions", () => {
       }),
     });
     activityMocks.admin = createSupabaseMock({
+      activity_events: createSupabaseResponse({ data: [] }),
       activity_log: createSupabaseResponse({ data: [] }),
       household_members: createSupabaseResponse({
         data: [{ user_id: "user_editor", email: "editor@example.test" }],
@@ -200,5 +201,144 @@ describe("activity server actions", () => {
         },
       },
     });
+  });
+
+  it("loads completed task activity with actor fallback", async () => {
+    const taskRow = {
+      id: "activity_task_1",
+      entity_type: "task",
+      entity_id: "task_1",
+      actor_user_id: "user_viewer",
+      actor_email: null,
+      action: "completed",
+      item_name: "Take out trash",
+      name_at_event: "Take out trash",
+      created_at: "2026-01-04T00:00:00.000Z",
+      changes: {
+        completed_at: "2026-01-04T00:00:00.000Z",
+      },
+    };
+
+    activityMocks.supabase = createSupabaseMock({
+      recent_activity: createSupabaseResponse({ data: [] }),
+    });
+    activityMocks.admin = createSupabaseMock({
+      activity_events: createSupabaseResponse({ data: [taskRow] }),
+      household_members: createSupabaseResponse({
+        data: [{ user_id: "user_viewer", email: "viewer@example.test" }],
+      }),
+    });
+    activityMocks.createClient.mockResolvedValue(activityMocks.supabase);
+    activityMocks.createAdminClient.mockReturnValue(activityMocks.admin);
+
+    const result = await getRecentActivityAction({
+      limit: 5,
+      action: "completed",
+      entityType: "task",
+    });
+
+    expect(activityMocks.supabase.__queries.get("recent_activity")).toBeUndefined();
+    const taskActivityQuery = activityMocks.admin.__queries.get("activity_events");
+    expect(taskActivityQuery.eq).toHaveBeenCalledWith("household_id", "household_1");
+    expect(taskActivityQuery.eq).toHaveBeenCalledWith("entity_type", "task");
+    expect(taskActivityQuery.eq).toHaveBeenCalledWith("action", "completed");
+    expect(result.error).toBeNull();
+    expect(result.data.items).toEqual([
+      expect.objectContaining({
+        entity_type: "task",
+        action: "completed",
+        actor_email: "viewer@example.test",
+        item_name: "Take out trash",
+      }),
+    ]);
+  });
+
+  it("merges task activity into all recent activity when the view omits tasks", async () => {
+    const itemRow = {
+      id: "activity_item_1",
+      entity_type: "item",
+      entity_id: "item_1",
+      actor_user_id: "user_owner",
+      actor_email: "owner@example.test",
+      action: "added",
+      item_name: "Rice",
+      created_at: "2026-01-04T00:00:00.000Z",
+      changes: {},
+    };
+    const taskRow = {
+      id: "activity_task_1",
+      entity_type: "task",
+      entity_id: "task_1",
+      actor_user_id: "user_owner",
+      actor_email: "owner@example.test",
+      action: "completed",
+      item_name: "Take out trash",
+      name_at_event: "Take out trash",
+      created_at: "2026-01-05T00:00:00.000Z",
+      changes: {
+        completed_at: "2026-01-05T00:00:00.000Z",
+      },
+    };
+
+    activityMocks.supabase = createSupabaseMock({
+      recent_activity: createSupabaseResponse({ data: [itemRow] }),
+    });
+    activityMocks.admin = createSupabaseMock({
+      activity_events: createSupabaseResponse({ data: [taskRow] }),
+    });
+    activityMocks.createClient.mockResolvedValue(activityMocks.supabase);
+    activityMocks.createAdminClient.mockReturnValue(activityMocks.admin);
+
+    const result = await getRecentActivityAction({ limit: 5 });
+
+    expect(result.error).toBeNull();
+    expect(result.data.items.map((row) => row.id)).toEqual([
+      "activity_task_1",
+      "activity_item_1",
+    ]);
+    expect(result.data.items[0]).toMatchObject({
+      entity_type: "task",
+      action: "completed",
+      item_name: "Take out trash",
+    });
+  });
+
+  it("filters recent activity by non-task entity type without task fallback rows", async () => {
+    const itemRow = {
+      id: "activity_item_1",
+      entity_type: "item",
+      entity_id: "item_1",
+      actor_user_id: "user_owner",
+      actor_email: "owner@example.test",
+      action: "updated",
+      item_name: "Rice",
+      created_at: "2026-01-06T00:00:00.000Z",
+      changes: {
+        quantity: { from: 1, to: 2 },
+      },
+    };
+
+    activityMocks.supabase = createSupabaseMock({
+      recent_activity: createSupabaseResponse({ data: [itemRow] }),
+    });
+    activityMocks.admin = createSupabaseMock();
+    activityMocks.createClient.mockResolvedValue(activityMocks.supabase);
+    activityMocks.createAdminClient.mockReturnValue(activityMocks.admin);
+
+    const result = await getRecentActivityAction({
+      limit: 5,
+      entityType: "item",
+    });
+
+    const activityQuery = activityMocks.supabase.__queries.get("recent_activity");
+    expect(activityQuery.eq).toHaveBeenCalledWith("entity_type", "item");
+    expect(activityMocks.admin.__queryHistory.get("activity_events")).toBeUndefined();
+    expect(result.error).toBeNull();
+    expect(result.data.items).toEqual([
+      expect.objectContaining({
+        entity_type: "item",
+        item_name: "Rice",
+      }),
+    ]);
   });
 });

--- a/tests/integration/authenticatedShellState.test.js
+++ b/tests/integration/authenticatedShellState.test.js
@@ -68,7 +68,9 @@ describe("authenticated app-shell state", () => {
       household_members: createSupabaseResponse({ count: 3 }),
       household_invites: createSupabaseResponse({ count: 1 }),
     });
-    shellMocks.supabase = createSupabaseMock();
+    shellMocks.supabase = createSupabaseMock({
+      tasks: createSupabaseResponse({ count: 12 }),
+    });
     shellMocks.supabase.auth.getUser.mockResolvedValue({
       data: {
         user: createTestUser({
@@ -139,8 +141,14 @@ describe("authenticated app-shell state", () => {
       categoriesCount: 9,
       itemsCount: 10,
       lowStockCount: 11,
+      tasksAttentionCount: 12,
       summaryCountsLoaded: true,
     });
+    const tasksQuery = shellMocks.supabase.__queries.get("tasks");
+    expect(tasksQuery.neq).toHaveBeenCalledWith("status", "completed");
+    expect(tasksQuery.not).toHaveBeenCalledWith("due_date", "is", null);
+    expect(tasksQuery.lte).toHaveBeenCalledWith("due_date", expect.any(String));
+    expect(tasksQuery.gte).not.toHaveBeenCalled();
     expect(shellMocks.supabase.rpc).toHaveBeenCalledWith(
       "wherekeep_inventory_summary_counts",
       { p_within_days: 3 }
@@ -174,6 +182,7 @@ describe("authenticated app-shell state", () => {
       locations: createSupabaseResponse({ count: 4 }),
       storage_areas: createSupabaseResponse({ count: 5 }),
       storage_categories: createSupabaseResponse({ count: 6 }),
+      tasks: createSupabaseResponse({ count: 7 }),
     });
     shellMocks.supabase.auth.getUser.mockResolvedValue({
       data: {
@@ -200,6 +209,7 @@ describe("authenticated app-shell state", () => {
       itemsCount: 9,
       lowStockCount: 0,
       shoppingListItemsCount: 0,
+      tasksAttentionCount: 7,
       summaryCountsLoaded: false,
     });
     expect(shellMocks.supabase.__queryHistory.get("items")).toHaveLength(3);

--- a/tests/integration/taskActions.test.js
+++ b/tests/integration/taskActions.test.js
@@ -1,0 +1,524 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createTestHousehold,
+  createTestLocation,
+  createTestMember,
+  createTestTask,
+  createTestUser,
+} from "@/tests/helpers/factories";
+import { createSupabaseMock, createSupabaseResponse } from "@/tests/mocks/supabase";
+import { HOUSEHOLD_ROLES } from "@/utils/householdRoles";
+
+const taskMocks = vi.hoisted(() => ({
+  getVerifiedSession: vi.fn(),
+  getHouseholdForUser: vi.fn(),
+  createAdminClient: vi.fn(),
+  revalidatePath: vi.fn(),
+  admin: null,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: taskMocks.revalidatePath,
+}));
+
+vi.mock("@/lib/verifiedSession", () => ({
+  getVerifiedSession: taskMocks.getVerifiedSession,
+}));
+
+vi.mock("@/utils/supabase/admin", () => ({
+  createAdminClient: taskMocks.createAdminClient,
+}));
+
+vi.mock("@/utils/households", async () => {
+  const roles = await vi.importActual("@/utils/householdRoles");
+  return {
+    ...roles,
+    getHouseholdForUser: taskMocks.getHouseholdForUser,
+    hasHouseholdInviteMetadata: vi.fn(() => false),
+  };
+});
+
+const {
+  completeTaskAction,
+  createTaskAction,
+  deleteTaskAction,
+  getTasksAction,
+  reopenTaskAction,
+  updateTaskAction,
+} = await import("@/app/actions/tasks");
+
+function setTaskContext({
+  role = HOUSEHOLD_ROLES.OWNER,
+  user = createTestUser(),
+} = {}) {
+  taskMocks.getVerifiedSession.mockResolvedValue({
+    user,
+    error: null,
+  });
+  taskMocks.getHouseholdForUser.mockResolvedValue({
+    household: createTestHousehold(),
+    member: createTestMember({
+      user_id: user.id,
+      email: user.email,
+      role,
+    }),
+  });
+}
+
+describe("task server actions", () => {
+  beforeEach(() => {
+    setTaskContext();
+    taskMocks.admin = createSupabaseMock();
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+  });
+
+  it("validates task names before reading session state", async () => {
+    const result = await createTaskAction({ title: "   " });
+
+    expect(result).toEqual({
+      data: null,
+      error: "Task name is required.",
+    });
+    expect(taskMocks.getVerifiedSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects viewer attempts to create tasks", async () => {
+    setTaskContext({ role: HOUSEHOLD_ROLES.VIEWER });
+
+    const result = await createTaskAction({ title: "Clean kitchen" });
+
+    expect(result).toEqual({
+      data: null,
+      error: "You do not have permission to create household tasks.",
+    });
+    expect(taskMocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("creates tasks scoped to the active household with valid assignment and location", async () => {
+    taskMocks.admin = createSupabaseMock({
+      household_members: createSupabaseResponse({
+        data: { user_id: "user_editor", email: "editor@example.test", role: "editor" },
+      }),
+      locations: createSupabaseResponse({
+        data: createTestLocation(),
+      }),
+      tasks: createSupabaseResponse({
+        data: createTestTask({
+          id: "task_created",
+          title: "Replace HVAC filter",
+          assigned_to: "user_editor",
+          priority: "high",
+          due_date: "2026-08-25",
+          is_recurring: true,
+          recurrence_type: "monthly",
+          recurrence_interval: 3,
+        }),
+      }),
+      activity_events: createSupabaseResponse(),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await createTaskAction({
+      title: " Replace HVAC filter ",
+      assignedTo: "user_editor",
+      locationId: "location_1",
+      priority: "high",
+      dueDate: "2026-08-25",
+      isRecurring: true,
+      recurrenceType: "monthly",
+      recurrenceInterval: 3,
+    });
+
+    const taskQuery = taskMocks.admin.__queries.get("tasks");
+    expect(taskQuery.insert).toHaveBeenCalledWith({
+      household_id: "household_1",
+      title: "Replace HVAC filter",
+      description: null,
+      assigned_to: "user_editor",
+      location_id: "location_1",
+      status: "todo",
+      priority: "high",
+      due_date: "2026-08-25",
+      is_recurring: true,
+      recurrence_type: "monthly",
+      recurrence_interval: 3,
+      created_by: "user_owner",
+    });
+    expect(result.error).toBeNull();
+    expect(result.data).toMatchObject({
+      id: "task_created",
+      title: "Replace HVAC filter",
+      assignedTo: "user_editor",
+      recurrenceType: "monthly",
+    });
+    expect(taskMocks.admin.__queries.get("activity_events").insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        household_id: "household_1",
+        actor_user_id: "user_owner",
+        actor_email: "owner@example.test",
+        entity_type: "task",
+        entity_id: "task_created",
+        action: "added",
+        name_at_event: "Replace HVAC filter",
+        item_name: "Replace HVAC filter",
+        changes: expect.objectContaining({
+          assigned_to: "user_editor",
+          priority: "high",
+          due_date: "2026-08-25",
+          recurrence_type: "monthly",
+        }),
+      })
+    );
+    expect(taskMocks.revalidatePath).toHaveBeenCalledWith("/tasks");
+  });
+
+  it("rejects assignment to users outside the household", async () => {
+    taskMocks.admin = createSupabaseMock({
+      household_members: createSupabaseResponse({ data: null }),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await createTaskAction({
+      title: "Clean kitchen",
+      assignedTo: "user_other",
+    });
+
+    expect(result).toEqual({
+      data: null,
+      error: "Assignee must belong to your household.",
+    });
+  });
+
+  it("loads tasks for only the active household", async () => {
+    taskMocks.admin = createSupabaseMock({
+      tasks: createSupabaseResponse({
+        data: [createTestTask({ id: "task_1" })],
+      }),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await getTasksAction({ status: "todo" });
+
+    const query = taskMocks.admin.__queries.get("tasks");
+    expect(query.eq).toHaveBeenCalledWith("household_id", "household_1");
+    expect(query.eq).toHaveBeenCalledWith("status", "todo");
+    expect(result).toEqual({
+      data: {
+        items: [
+          expect.objectContaining({
+            id: "task_1",
+            householdId: "household_1",
+          }),
+        ],
+      },
+      error: null,
+    });
+  });
+
+  it("lets editors update and assign household tasks", async () => {
+    setTaskContext({
+      role: HOUSEHOLD_ROLES.EDITOR,
+      user: createTestUser({ id: "user_editor", email: "editor@example.test" }),
+    });
+    taskMocks.admin = createSupabaseMock({
+      tasks: [
+        createSupabaseResponse({ data: createTestTask({ id: "task_1" }) }),
+        createSupabaseResponse({
+          data: createTestTask({
+            id: "task_1",
+            title: "Clean the kitchen",
+            assigned_to: "user_viewer",
+            priority: "high",
+          }),
+        }),
+      ],
+      household_members: createSupabaseResponse({
+        data: { user_id: "user_viewer", email: "viewer@example.test", role: "viewer" },
+      }),
+      activity_events: createSupabaseResponse(),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await updateTaskAction("task_1", {
+      title: "Clean the kitchen",
+      assignedTo: "user_viewer",
+      priority: "high",
+    });
+
+    const taskQueries = taskMocks.admin.__queryHistory.get("tasks");
+    expect(taskQueries[0].eq).toHaveBeenCalledWith("household_id", "household_1");
+    expect(taskQueries[1].update).toHaveBeenCalledWith({
+      title: "Clean the kitchen",
+      assigned_to: "user_viewer",
+      priority: "high",
+    });
+    expect(result.error).toBeNull();
+    expect(result.data).toMatchObject({
+      title: "Clean the kitchen",
+      assignedTo: "user_viewer",
+      priority: "high",
+    });
+  });
+
+  it("lets assigned viewers complete and reopen their own tasks", async () => {
+    setTaskContext({
+      role: HOUSEHOLD_ROLES.VIEWER,
+      user: createTestUser({ id: "user_viewer", email: "viewer@example.test" }),
+    });
+    taskMocks.admin = createSupabaseMock({
+      tasks: [
+        createSupabaseResponse({
+          data: createTestTask({ id: "task_1", assigned_to: "user_viewer" }),
+        }),
+        createSupabaseResponse({
+          data: createTestTask({
+            id: "task_1",
+            assigned_to: "user_viewer",
+            status: "completed",
+            completed_by: "user_viewer",
+          }),
+        }),
+        createSupabaseResponse({
+          data: createTestTask({
+            id: "task_1",
+            assigned_to: "user_viewer",
+            status: "completed",
+            completed_by: "user_viewer",
+          }),
+        }),
+        createSupabaseResponse({
+          data: createTestTask({
+            id: "task_1",
+            assigned_to: "user_viewer",
+            status: "todo",
+          }),
+        }),
+      ],
+      activity_events: createSupabaseResponse(),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const completeResult = await completeTaskAction("task_1");
+    const reopenResult = await reopenTaskAction("task_1");
+    const taskQueries = taskMocks.admin.__queryHistory.get("tasks");
+
+    expect(taskQueries[1].update).toHaveBeenCalledWith({
+      status: "completed",
+      completed_at: expect.any(String),
+      completed_by: "user_viewer",
+    });
+    expect(taskQueries[3].update).toHaveBeenCalledWith({
+      status: "todo",
+      completed_at: null,
+      completed_by: null,
+    });
+    const activityQueries = taskMocks.admin.__queryHistory.get("activity_events");
+    expect(activityQueries[0].insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        household_id: "household_1",
+        actor_user_id: "user_viewer",
+        actor_email: "viewer@example.test",
+        entity_type: "task",
+        entity_id: "task_1",
+        action: "completed",
+        name_at_event: "Take out trash",
+        item_name: "Take out trash",
+        changes: expect.objectContaining({
+          completed_at: expect.any(String),
+        }),
+      })
+    );
+    expect(activityQueries[1].insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        household_id: "household_1",
+        actor_user_id: "user_viewer",
+        actor_email: "viewer@example.test",
+        entity_type: "task",
+        entity_id: "task_1",
+        action: "updated",
+        changes: { status: "todo", reopened: true },
+      })
+    );
+    expect(completeResult.error).toBeNull();
+    expect(reopenResult.error).toBeNull();
+  });
+
+  it("rejects viewer completion of another member's task", async () => {
+    setTaskContext({
+      role: HOUSEHOLD_ROLES.VIEWER,
+      user: createTestUser({ id: "user_viewer", email: "viewer@example.test" }),
+    });
+    taskMocks.admin = createSupabaseMock({
+      tasks: createSupabaseResponse({
+        data: createTestTask({ id: "task_1", assigned_to: "user_other" }),
+      }),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await completeTaskAction("task_1");
+
+    expect(result).toEqual({
+      data: null,
+      error: "You do not have permission to complete this task.",
+    });
+  });
+
+  it("lets household members complete unassigned tasks", async () => {
+    setTaskContext({
+      role: HOUSEHOLD_ROLES.VIEWER,
+      user: createTestUser({ id: "user_viewer", email: "viewer@example.test" }),
+    });
+    taskMocks.admin = createSupabaseMock({
+      tasks: [
+        createSupabaseResponse({
+          data: createTestTask({ id: "task_1", assigned_to: null }),
+        }),
+        createSupabaseResponse({
+          data: createTestTask({
+            id: "task_1",
+            assigned_to: null,
+            status: "completed",
+            completed_by: "user_viewer",
+          }),
+        }),
+      ],
+      activity_events: createSupabaseResponse(),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await completeTaskAction("task_1");
+    const taskQueries = taskMocks.admin.__queryHistory.get("tasks");
+
+    expect(taskQueries[1].update).toHaveBeenCalledWith({
+      status: "completed",
+      completed_at: expect.any(String),
+      completed_by: "user_viewer",
+    });
+    expect(result.error).toBeNull();
+  });
+
+  it("rejects editor completion of another member's assigned task", async () => {
+    setTaskContext({
+      role: HOUSEHOLD_ROLES.EDITOR,
+      user: createTestUser({ id: "user_editor", email: "editor@example.test" }),
+    });
+    taskMocks.admin = createSupabaseMock({
+      tasks: createSupabaseResponse({
+        data: createTestTask({ id: "task_1", assigned_to: "user_other" }),
+      }),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await completeTaskAction("task_1");
+
+    expect(result).toEqual({
+      data: null,
+      error: "You do not have permission to complete this task.",
+    });
+  });
+
+  it("generates the next occurrence when completing recurring tasks", async () => {
+    taskMocks.admin = createSupabaseMock({
+      tasks: [
+        createSupabaseResponse({
+          data: createTestTask({
+            id: "task_1",
+            due_date: "2026-08-18",
+            is_recurring: true,
+            recurrence_type: "weekly",
+            recurrence_interval: 1,
+          }),
+        }),
+        createSupabaseResponse({
+          data: createTestTask({
+            id: "task_1",
+            status: "completed",
+            due_date: "2026-08-18",
+            is_recurring: true,
+            recurrence_type: "weekly",
+            recurrence_interval: 1,
+          }),
+        }),
+        createSupabaseResponse({ data: null }),
+        createSupabaseResponse({
+          data: createTestTask({
+            id: "task_2",
+            due_date: "2026-08-25",
+            recurring_parent_task_id: "task_1",
+            is_recurring: true,
+            recurrence_type: "weekly",
+          }),
+        }),
+      ],
+      activity_events: createSupabaseResponse(),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await completeTaskAction("task_1");
+    const taskQueries = taskMocks.admin.__queryHistory.get("tasks");
+
+    expect(taskQueries[3].insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        household_id: "household_1",
+        due_date: "2026-08-25",
+        recurring_parent_task_id: "task_1",
+        status: "todo",
+      })
+    );
+    expect(result.error).toBeNull();
+    expect(result.data.nextTask).toMatchObject({
+      id: "task_2",
+      dueDate: "2026-08-25",
+      recurringParentTaskId: "task_1",
+    });
+  });
+
+  it("deletes only tasks from the active household", async () => {
+    taskMocks.admin = createSupabaseMock({
+      tasks: createSupabaseResponse({ data: createTestTask({ id: "task_1" }) }),
+      activity_events: createSupabaseResponse(),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await deleteTaskAction("task_1");
+
+    const taskQueries = taskMocks.admin.__queryHistory.get("tasks");
+    expect(taskQueries[0].eq).toHaveBeenCalledWith("household_id", "household_1");
+    expect(taskQueries[1].delete).toHaveBeenCalled();
+    expect(taskQueries[1].eq).toHaveBeenCalledWith("household_id", "household_1");
+    expect(result).toEqual({
+      data: { deletedId: "task_1" },
+      error: null,
+    });
+    expect(taskMocks.admin.__queries.get("activity_events").insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        household_id: "household_1",
+        actor_user_id: "user_owner",
+        actor_email: "owner@example.test",
+        entity_type: "task",
+        entity_id: "task_1",
+        action: "deleted",
+        name_at_event: "Take out trash",
+        item_name: "Take out trash",
+        changes: { deleted: true },
+      })
+    );
+  });
+
+  it("rejects cross-household task ids that do not resolve in the active household", async () => {
+    taskMocks.admin = createSupabaseMock({
+      tasks: createSupabaseResponse({ data: null }),
+    });
+    taskMocks.createAdminClient.mockReturnValue(taskMocks.admin);
+
+    const result = await updateTaskAction("task_other", { title: "Nope" });
+
+    const query = taskMocks.admin.__queries.get("tasks");
+    expect(query.eq).toHaveBeenCalledWith("id", "task_other");
+    expect(query.eq).toHaveBeenCalledWith("household_id", "household_1");
+    expect(result).toEqual({
+      data: null,
+      error: "Task not found for this household.",
+    });
+  });
+});

--- a/tests/unit/tasks.test.js
+++ b/tests/unit/tasks.test.js
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { createTestMember, createTestTask } from "@/tests/helpers/factories";
+import { HOUSEHOLD_ROLES } from "@/utils/householdRoles";
+import {
+  TASK_PRIORITY,
+  TASK_STATUS,
+  calculateNextTaskDueDate,
+  canCompleteTask,
+  canCreateTask,
+  canDeleteTask,
+  canEditTask,
+  groupTasksByDate,
+  isTaskDueToday,
+  isTaskOverdue,
+  isTaskUpcoming,
+  sortTasks,
+  summarizeTasks,
+  validateTaskPayload,
+} from "@/utils/tasks";
+
+const TODAY = new Date("2026-08-17T15:30:00");
+
+describe("task utilities", () => {
+  it("groups tasks by overdue, today, upcoming, and completed", () => {
+    const overdue = createTestTask({ id: "overdue", due_date: "2026-08-16" });
+    const today = createTestTask({ id: "today", due_date: "2026-08-17" });
+    const upcoming = createTestTask({ id: "upcoming", due_date: "2026-08-20" });
+    const completed = createTestTask({
+      id: "completed",
+      status: TASK_STATUS.COMPLETED,
+      due_date: "2026-08-15",
+      completed_at: "2026-08-17T12:00:00.000Z",
+    });
+
+    expect(isTaskOverdue(overdue, TODAY)).toBe(true);
+    expect(isTaskDueToday(today, TODAY)).toBe(true);
+    expect(isTaskUpcoming(upcoming, TODAY, 7)).toBe(true);
+
+    expect(groupTasksByDate([overdue, today, upcoming, completed], TODAY)).toEqual({
+      overdue: [overdue],
+      today: [today],
+      upcoming: [upcoming],
+      completed: [completed],
+    });
+  });
+
+  it("summarizes active, due-today, upcoming, and completed-this-month tasks", () => {
+    const tasks = [
+      createTestTask({ id: "today", due_date: "2026-08-17" }),
+      createTestTask({ id: "tomorrow", due_date: "2026-08-18" }),
+      createTestTask({ id: "later", due_date: "2026-09-01" }),
+      createTestTask({
+        id: "completed",
+        status: TASK_STATUS.COMPLETED,
+        completed_at: "2026-08-10T00:00:00.000Z",
+      }),
+    ];
+
+    expect(summarizeTasks(tasks, TODAY)).toEqual({
+      active: 3,
+      dueToday: 1,
+      upcoming: 1,
+      completedThisMonth: 1,
+    });
+  });
+
+  it("sorts by priority and due date", () => {
+    const low = createTestTask({ id: "low", title: "C", priority: TASK_PRIORITY.LOW });
+    const high = createTestTask({ id: "high", title: "B", priority: TASK_PRIORITY.HIGH });
+    const medium = createTestTask({
+      id: "medium",
+      title: "A",
+      priority: TASK_PRIORITY.MEDIUM,
+    });
+
+    expect(sortTasks([low, high, medium], "priority").map((task) => task.id)).toEqual([
+      "high",
+      "medium",
+      "low",
+    ]);
+
+    expect(
+      sortTasks(
+        [
+          createTestTask({ id: "no_due", due_date: null }),
+          createTestTask({ id: "soon", due_date: "2026-08-18" }),
+          createTestTask({ id: "today", due_date: "2026-08-17" }),
+        ],
+        "due_date"
+      ).map((task) => task.id)
+    ).toEqual(["today", "soon", "no_due"]);
+  });
+
+  it("calculates recurring due dates with month and leap-year edges", () => {
+    expect(calculateNextTaskDueDate("2026-08-17", "daily", 1)).toBe("2026-08-18");
+    expect(calculateNextTaskDueDate("2026-08-17", "weekly", 2)).toBe("2026-08-31");
+    expect(calculateNextTaskDueDate("2026-01-31", "monthly", 1)).toBe("2026-02-28");
+    expect(calculateNextTaskDueDate("2024-01-31", "monthly", 1)).toBe("2024-02-29");
+    expect(calculateNextTaskDueDate("2024-02-29", "yearly", 1)).toBe("2025-02-28");
+  });
+
+  it("validates task payloads and recurrence fields", () => {
+    expect(validateTaskPayload({ title: "   " })).toEqual({
+      data: null,
+      error: "Task name is required.",
+    });
+
+    expect(
+      validateTaskPayload({
+        title: "  Clean kitchen  ",
+        priority: "unknown",
+        dueDate: "2026-08-17",
+        isRecurring: true,
+        recurrenceType: "weekly",
+        recurrenceInterval: "2",
+      })
+    ).toEqual({
+      data: {
+        title: "Clean kitchen",
+        description: null,
+        assignedTo: null,
+        locationId: null,
+        status: "todo",
+        priority: "medium",
+        dueDate: "2026-08-17",
+        isRecurring: true,
+        recurrenceType: "weekly",
+        recurrenceInterval: 2,
+      },
+      error: null,
+    });
+  });
+
+  it("enforces task permissions by household role and assignment", () => {
+    const owner = createTestMember({ role: HOUSEHOLD_ROLES.OWNER });
+    const editor = createTestMember({ role: HOUSEHOLD_ROLES.EDITOR });
+    const viewer = createTestMember({
+      role: HOUSEHOLD_ROLES.VIEWER,
+      user_id: "user_viewer",
+    });
+    const assignedTask = createTestTask({ assigned_to: "user_viewer" });
+    const otherTask = createTestTask({ assigned_to: "user_other" });
+    const unassignedTask = createTestTask({ assigned_to: null });
+
+    expect(canCreateTask(owner)).toBe(true);
+    expect(canEditTask(editor)).toBe(true);
+    expect(canDeleteTask(editor)).toBe(true);
+    expect(canCreateTask(viewer)).toBe(false);
+    expect(canEditTask(viewer)).toBe(false);
+    expect(canCompleteTask(viewer, "user_viewer", assignedTask)).toBe(true);
+    expect(canCompleteTask(viewer, "user_viewer", unassignedTask)).toBe(true);
+    expect(canCompleteTask(viewer, "user_viewer", otherTask)).toBe(false);
+    expect(canCompleteTask(editor, "user_editor", otherTask)).toBe(false);
+    expect(canCompleteTask(editor, "user_editor", unassignedTask)).toBe(true);
+  });
+});

--- a/utils/tasks.js
+++ b/utils/tasks.js
@@ -1,0 +1,345 @@
+import { canEditHouseholdInventory } from "@/utils/householdRoles";
+import { addDays, parsePantryDate, toDateString } from "@/utils/pantry/date";
+
+export const TASK_STATUS = {
+  TODO: "todo",
+  IN_PROGRESS: "in_progress",
+  COMPLETED: "completed",
+};
+
+export const TASK_PRIORITY = {
+  LOW: "low",
+  MEDIUM: "medium",
+  HIGH: "high",
+};
+
+export const TASK_RECURRENCE = {
+  DAILY: "daily",
+  WEEKLY: "weekly",
+  MONTHLY: "monthly",
+  YEARLY: "yearly",
+};
+
+export const TASK_SORT = {
+  DUE_DATE: "due_date",
+  NEWEST: "newest",
+  OLDEST: "oldest",
+  PRIORITY: "priority",
+  ALPHABETICAL: "alphabetical",
+};
+
+const VALID_STATUSES = new Set(Object.values(TASK_STATUS));
+const VALID_PRIORITIES = new Set(Object.values(TASK_PRIORITY));
+const VALID_RECURRENCES = new Set(Object.values(TASK_RECURRENCE));
+const PRIORITY_WEIGHT = {
+  [TASK_PRIORITY.HIGH]: 0,
+  [TASK_PRIORITY.MEDIUM]: 1,
+  [TASK_PRIORITY.LOW]: 2,
+};
+
+export function normalizeTaskTitle(value) {
+  return typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+}
+
+export function normalizeTaskDescription(value) {
+  const description = typeof value === "string" ? value.trim() : "";
+  return description || null;
+}
+
+export function normalizeTaskStatus(value, fallback = TASK_STATUS.TODO) {
+  const status = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return VALID_STATUSES.has(status) ? status : fallback;
+}
+
+export function normalizeTaskPriority(value, fallback = TASK_PRIORITY.MEDIUM) {
+  const priority = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return VALID_PRIORITIES.has(priority) ? priority : fallback;
+}
+
+export function normalizeTaskRecurrenceType(value) {
+  const recurrence = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return VALID_RECURRENCES.has(recurrence) ? recurrence : null;
+}
+
+export function normalizeTaskRecurrenceInterval(value, fallback = 1) {
+  const interval = Number.parseInt(String(value), 10);
+  return Number.isFinite(interval) && interval >= 1 ? interval : fallback;
+}
+
+export function normalizeTaskDate(value) {
+  const date = parsePantryDate(value);
+  return date ? toDateString(date) : null;
+}
+
+export function normalizeTaskId(value) {
+  if (value === null || value === undefined || value === "") return null;
+  return String(value);
+}
+
+export function validateTaskPayload(values = {}, options = {}) {
+  const requireTitle = options.requireTitle !== false;
+  const patch = options.patch === true;
+  const data = {};
+
+  if (!patch || "title" in values) {
+    const title = normalizeTaskTitle(values.title);
+    if (requireTitle && !title) {
+      return { data: null, error: "Task name is required." };
+    }
+    if (title) data.title = title;
+  }
+
+  if (!patch || "description" in values) {
+    data.description = normalizeTaskDescription(values.description);
+  }
+
+  if (!patch || "assignedTo" in values || "assigned_to" in values) {
+    data.assignedTo = normalizeTaskId(values.assignedTo ?? values.assigned_to);
+  }
+
+  if (!patch || "locationId" in values || "location_id" in values) {
+    data.locationId = normalizeTaskId(values.locationId ?? values.location_id);
+  }
+
+  if (!patch || "status" in values) {
+    data.status = normalizeTaskStatus(values.status);
+  }
+
+  if (!patch || "priority" in values) {
+    data.priority = normalizeTaskPriority(values.priority);
+  }
+
+  if (!patch || "dueDate" in values || "due_date" in values) {
+    const rawDueDate = values.dueDate ?? values.due_date;
+    if (rawDueDate) {
+      const dueDate = normalizeTaskDate(rawDueDate);
+      if (!dueDate) return { data: null, error: "Enter a valid due date." };
+      data.dueDate = dueDate;
+    } else {
+      data.dueDate = null;
+    }
+  }
+
+  if (
+    !patch ||
+    "isRecurring" in values ||
+    "is_recurring" in values ||
+    "recurrenceType" in values ||
+    "recurrence_type" in values ||
+    "recurrenceInterval" in values ||
+    "recurrence_interval" in values
+  ) {
+    const isRecurring = Boolean(values.isRecurring ?? values.is_recurring);
+    const recurrenceType = normalizeTaskRecurrenceType(
+      values.recurrenceType ?? values.recurrence_type
+    );
+    const recurrenceInterval = normalizeTaskRecurrenceInterval(
+      values.recurrenceInterval ?? values.recurrence_interval,
+      1
+    );
+
+    if (isRecurring && !recurrenceType) {
+      return { data: null, error: "Choose how often this task repeats." };
+    }
+
+    data.isRecurring = isRecurring;
+    data.recurrenceType = isRecurring ? recurrenceType : null;
+    data.recurrenceInterval = isRecurring ? recurrenceInterval : 1;
+  }
+
+  return { data, error: null };
+}
+
+export function canViewTasks(member) {
+  return Boolean(member?.household_id || member?.householdId);
+}
+
+export function canCreateTask(member) {
+  return canEditHouseholdInventory(member);
+}
+
+export function canEditTask(member) {
+  return canEditHouseholdInventory(member);
+}
+
+export function canDeleteTask(member) {
+  return canEditHouseholdInventory(member);
+}
+
+export function isTaskAssignedToUser(task, userId) {
+  const assignedTo = task?.assigned_to ?? task?.assignedTo;
+  return Boolean(assignedTo && userId && String(assignedTo) === String(userId));
+}
+
+export function isTaskUnassigned(task) {
+  const assignedTo = task?.assigned_to ?? task?.assignedTo;
+  return !assignedTo;
+}
+
+export function canCompleteTask(member, userId, task) {
+  if (!canViewTasks(member) || !userId) return false;
+  return isTaskUnassigned(task) || isTaskAssignedToUser(task, userId);
+}
+
+export function canReopenTask(member, userId, task) {
+  return canCompleteTask(member, userId, task);
+}
+
+export function isTaskCompleted(task) {
+  return normalizeTaskStatus(task?.status) === TASK_STATUS.COMPLETED;
+}
+
+function startOfLocalDay(value) {
+  const date = value ? new Date(value) : new Date();
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function compareDateOnly(left, right) {
+  const leftDate = parsePantryDate(left);
+  const rightDate = startOfLocalDay(right);
+  if (!leftDate) return null;
+  leftDate.setHours(0, 0, 0, 0);
+  return leftDate.getTime() - rightDate.getTime();
+}
+
+export function isTaskOverdue(task, today = new Date()) {
+  if (isTaskCompleted(task)) return false;
+  const diff = compareDateOnly(task?.due_date ?? task?.dueDate, today);
+  return diff !== null && diff < 0;
+}
+
+export function isTaskDueToday(task, today = new Date()) {
+  if (isTaskCompleted(task)) return false;
+  const diff = compareDateOnly(task?.due_date ?? task?.dueDate, today);
+  return diff === 0;
+}
+
+export function isTaskUpcoming(task, today = new Date(), days = 7) {
+  if (isTaskCompleted(task)) return false;
+  const dueDate = task?.due_date ?? task?.dueDate;
+  if (!dueDate) return false;
+  const diff = compareDateOnly(dueDate, today);
+  if (diff === null || diff <= 0) return false;
+  const maxDiff = addDays(startOfLocalDay(today), days).getTime() - startOfLocalDay(today).getTime();
+  return diff <= maxDiff;
+}
+
+export function getTaskDateSection(task, today = new Date()) {
+  if (isTaskCompleted(task)) return "completed";
+  if (isTaskOverdue(task, today)) return "overdue";
+  if (isTaskDueToday(task, today)) return "today";
+  return "upcoming";
+}
+
+export function groupTasksByDate(tasks = [], today = new Date()) {
+  return (tasks ?? []).reduce(
+    (groups, task) => {
+      groups[getTaskDateSection(task, today)].push(task);
+      return groups;
+    },
+    { overdue: [], today: [], upcoming: [], completed: [] }
+  );
+}
+
+export function summarizeTasks(tasks = [], today = new Date()) {
+  const startOfMonth = new Date(today);
+  startOfMonth.setHours(0, 0, 0, 0);
+  startOfMonth.setDate(1);
+  const nextMonth = new Date(startOfMonth);
+  nextMonth.setMonth(nextMonth.getMonth() + 1);
+
+  return (tasks ?? []).reduce(
+    (summary, task) => {
+      if (!isTaskCompleted(task)) summary.active += 1;
+      if (isTaskDueToday(task, today)) summary.dueToday += 1;
+      if (isTaskUpcoming(task, today, 7)) summary.upcoming += 1;
+
+      const completedAt = task.completed_at ?? task.completedAt;
+      const completedDate = completedAt ? new Date(completedAt) : null;
+      if (
+        isTaskCompleted(task) &&
+        completedDate &&
+        completedDate >= startOfMonth &&
+        completedDate < nextMonth
+      ) {
+        summary.completedThisMonth += 1;
+      }
+
+      return summary;
+    },
+    { active: 0, dueToday: 0, upcoming: 0, completedThisMonth: 0 }
+  );
+}
+
+export function sortTasks(tasks = [], sortBy = TASK_SORT.DUE_DATE) {
+  const safeSort = Object.values(TASK_SORT).includes(sortBy)
+    ? sortBy
+    : TASK_SORT.DUE_DATE;
+
+  return [...(tasks ?? [])].sort((left, right) => {
+    if (safeSort === TASK_SORT.NEWEST || safeSort === TASK_SORT.OLDEST) {
+      const leftTime = new Date(left.created_at ?? left.createdAt ?? 0).getTime();
+      const rightTime = new Date(right.created_at ?? right.createdAt ?? 0).getTime();
+      return safeSort === TASK_SORT.NEWEST ? rightTime - leftTime : leftTime - rightTime;
+    }
+
+    if (safeSort === TASK_SORT.PRIORITY) {
+      const leftPriority = PRIORITY_WEIGHT[normalizeTaskPriority(left.priority)];
+      const rightPriority = PRIORITY_WEIGHT[normalizeTaskPriority(right.priority)];
+      if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+    }
+
+    if (safeSort === TASK_SORT.ALPHABETICAL) {
+      return String(left.title || "").localeCompare(String(right.title || ""));
+    }
+
+    const leftDue = parsePantryDate(left.due_date ?? left.dueDate);
+    const rightDue = parsePantryDate(right.due_date ?? right.dueDate);
+    if (leftDue && rightDue && leftDue.getTime() !== rightDue.getTime()) {
+      return leftDue.getTime() - rightDue.getTime();
+    }
+    if (leftDue && !rightDue) return -1;
+    if (!leftDue && rightDue) return 1;
+
+    return String(left.title || "").localeCompare(String(right.title || ""));
+  });
+}
+
+function lastDayOfMonth(year, monthIndex) {
+  return new Date(year, monthIndex + 1, 0).getDate();
+}
+
+function addMonthsClamped(date, months) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const day = date.getDate();
+  const target = new Date(year, month + months, 1);
+  target.setDate(Math.min(day, lastDayOfMonth(target.getFullYear(), target.getMonth())));
+  return target;
+}
+
+export function calculateNextTaskDueDate(dueDate, recurrenceType, interval = 1) {
+  const date = parsePantryDate(dueDate);
+  const type = normalizeTaskRecurrenceType(recurrenceType);
+  const safeInterval = normalizeTaskRecurrenceInterval(interval);
+  if (!date || !type) return null;
+
+  if (type === TASK_RECURRENCE.DAILY) {
+    return toDateString(addDays(date, safeInterval));
+  }
+
+  if (type === TASK_RECURRENCE.WEEKLY) {
+    return toDateString(addDays(date, safeInterval * 7));
+  }
+
+  if (type === TASK_RECURRENCE.MONTHLY) {
+    return toDateString(addMonthsClamped(date, safeInterval));
+  }
+
+  if (type === TASK_RECURRENCE.YEARLY) {
+    return toDateString(addMonthsClamped(date, safeInterval * 12));
+  }
+
+  return null;
+}


### PR DESCRIPTION
- add tasks schema, server actions, permissions, recurrence, and tests
- build responsive Tasks UI with filters, task cards, mobile layout, and dashboard widget
- log task create/update/complete/delete events into recent activity
- add activity type filtering and task activity fallback loading
- show due/overdue task counts in navigation and notifications
- improve dropdown positioning, task toasts, and mobile task controls
- optimize activity and navigation count queries and remove unused task helper